### PR TITLE
move `typescript` to devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,17 @@
 {
     "name": "typeorm-extension",
-    "version": "0.2.8",
+    "version": "0.2.9",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
-            "version": "0.2.8",
+            "version": "0.2.9",
             "license": "MIT",
             "dependencies": {
                 "change-case": "^4.1.2",
                 "glob": "^7.1.7",
                 "minimatch": "^3.0.4",
                 "typeorm": "^0.2.34",
-                "typescript": "^4.3.4",
                 "yargs": "^17.0.1"
             },
             "bin": {
@@ -31,7 +30,8 @@
                 "ts-jest": "^27.0.3",
                 "ts-node": "^10.0.0",
                 "tslint": "^6.1.3",
-                "tslint-config-prettier": "^1.18.0"
+                "tslint-config-prettier": "^1.18.0",
+                "typescript": "^4.3.4"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -5069,6 +5069,7 @@
             "version": "4.3.5",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
             "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+            "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -9316,7 +9317,8 @@
         "typescript": {
             "version": "4.3.5",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-            "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA=="
+            "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+            "dev": true
         },
         "universalify": {
             "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
         "glob": "^7.1.7",
         "minimatch": "^3.0.4",
         "typeorm": "^0.2.34",
-        "typescript": "^4.3.4",
         "yargs": "^17.0.1"
     },
     "devDependencies": {
@@ -53,6 +52,7 @@
         "ts-jest": "^27.0.3",
         "ts-node": "^10.0.0",
         "tslint": "^6.1.3",
-        "tslint-config-prettier": "^1.18.0"
+        "tslint-config-prettier": "^1.18.0",
+        "typescript": "^4.3.4"
     }
 }


### PR DESCRIPTION
`typescript` module is need on development, and it is unnecessary at runtime.