### PR TITLE
synchronize = true can cause loss of data.

### DIFF
--- a/src/database/type.ts
+++ b/src/database/type.ts
@@ -31,7 +31,7 @@ export type DatabaseCreateContext = DatabaseBaseContext & {
     /**
      * Synchronize database entities.
      *
-     * default: true
+     * default: false
      */
     synchronize?: boolean
 };

--- a/src/database/utils/context.ts
+++ b/src/database/utils/context.ts
@@ -35,7 +35,7 @@ export async function buildDatabaseCreateContext(
     context = await setDatabaseContextOptions(context);
 
     if (typeof context.synchronize === 'undefined') {
-        context.synchronize = true;
+        context.synchronize = false;
     }
 
     if (typeof context.ifNotExist === 'undefined') {


### PR DESCRIPTION
Default should be synchronize = false to avoid data loss in production.

This might be breaking changes for development but not for production. 