### PR TITLE
fix: incorrect index

### DIFF
--- a/src/data-source/find/module.ts
+++ b/src/data-source/find/module.ts
@@ -82,7 +82,7 @@ export async function findDataSource(
             if (typeof fileExports === 'object') {
                 const keys = Object.keys(fileExports);
                 for (let j = 0; j < keys.length; j++) {
-                    const value = (fileExports as Record<string, any>)[keys[i]];
+                    const value = (fileExports as Record<string, any>)[keys[j]];
 
                     if (InstanceChecker.isDataSource(value)) {
                         return value;

--- a/test/data/typeorm/data-source-default.ts
+++ b/test/data/typeorm/data-source-default.ts
@@ -1,7 +1,9 @@
-import {DataSource} from "typeorm";
+import {DataSource, DataSourceOptions} from "typeorm";
 import path from "path";
 
-export default new DataSource({
+export const options: DataSourceOptions = {
     type: 'better-sqlite3',
     database: path.join(__dirname, 'db.sqlite')
-})
+}
+
+export default new DataSource(options)

--- a/test/data/typeorm/data-source.ts
+++ b/test/data/typeorm/data-source.ts
@@ -3,7 +3,7 @@ import path from "path";
 import {User} from "../entity/user";
 import {SeederOptions} from "../../../src";
 
-const options : DataSourceOptions & SeederOptions = {
+export const options : DataSourceOptions & SeederOptions = {
     type: 'better-sqlite3',
     entities: [User],
     database: path.join(__dirname, 'db.sqlite'),


### PR DESCRIPTION
When non DataSource export exists in dataSource file, Index for `keys` is incorrect, so `findDataSource` returns `undefined`.
