### PR TITLE
Improve/add response for run seeder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
     "name": "typeorm-extension",
-    "version": "2.1.9",
+    "version": "2.1.10",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
-            "version": "2.1.9",
+            "version": "2.1.10",
             "license": "MIT",
             "dependencies": {
                 "@faker-js/faker": "^7.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "typeorm-extension",
-    "version": "2.1.9",
+    "version": "2.1.10",
     "description": "Typeorm extension to create/drop database, simple seeding data sets, ...",
     "author": {
         "name": "Peter Placzek",

--- a/test/data/seed/user.ts
+++ b/test/data/seed/user.ts
@@ -6,7 +6,7 @@ export default class UserSeeder implements Seeder {
     public async run(
         dataSource: DataSource,
         factoryManager?: SeederFactoryManager
-    ) : Promise<void> {
+    ) : Promise<any> {
         const repository =  dataSource.getRepository(User);
         await repository.insert([
             {firstName: 'Caleb', lastName: 'Barrows', email: 'caleb.barrows@gmail.com'}
@@ -14,11 +14,16 @@ export default class UserSeeder implements Seeder {
 
         // ---------------------------------------------------
 
+        const users = [] as any[];
         const userFactory = await factoryManager.get(User);
         // save 1 factory generated entity, to the database
-        await userFactory.save();
+        const user1 = await userFactory.save();
+        users.push(user1);
 
         // save 5 factory generated entities, to the database
-        await userFactory.saveMany(5);
+        const users2 = await userFactory.saveMany(5);
+        users.push(users2);
+
+        return users;
     }
 }

--- a/test/unit/seeder/seeder.spec.ts
+++ b/test/unit/seeder/seeder.spec.ts
@@ -1,4 +1,4 @@
-import {runSeeder, runSeeders, useDataSource} from "../../../src";
+import {runSeeder, runSeeders, runSeederWithResponse, useDataSource} from "../../../src";
 import {User} from "../../data/entity/user";
 import {destroyTestDatabase, setupTestDatabase} from "../../data/typeorm/utils";
 import '../../data/factory/user';
@@ -48,5 +48,18 @@ describe('src/seeder/index.ts', function () {
 
         expect(entities).toBeDefined();
         expect(entities.length).toBeGreaterThanOrEqual(7);
+    })
+
+    it('should seed with explicit definition', async () => {
+        const dataSource = await useDataSource();
+
+        const resp = await runSeederWithResponse(dataSource, UserSeeder);
+
+        const repository = dataSource.getRepository(User);
+        const entities = await repository.find();
+
+        expect(entities).toBeDefined();
+        expect(entities.length).toBeGreaterThanOrEqual(7);
+        expect(resp.length).toBeGreaterThanOrEqual(6);
     })
 });


### PR DESCRIPTION
It would be helpful to return a response from runSeeder if used inside integration tests in order to verify what should be returned from the tested services.