### PR TITLE
feat: sort by filename when using seed pattern

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -18,16 +18,27 @@ This is a library to
 
 **Table of Contents**
 
-- [Installation](#installation)
-- [Documentation](#documentation)
-- [Usage](#usage)
+- [Typeorm Extension 🚀](#typeorm-extension-)
+  - [Installation](#installation)
+  - [Documentation](#documentation)
+  - [Usage](#usage)
     - [CLI](#cli)
+      - [Options](#options)
     - [Database](#database)
+      - [Create](#create)
+      - [Drop](#drop)
     - [Instances](#instances)
+      - [Single](#single)
+      - [Multiple](#multiple)
     - [Seeding](#seeding)
+      - [Configuration](#configuration)
+      - [Entity](#entity)
+      - [Factory](#factory)
+      - [Seed](#seed)
+      - [Execute](#execute)
     - [Query](#query)
-- [Contributing](#contributing)
-- [License](#license)
+  - [Contributing](#contributing)
+  - [License](#license)
 
 ## Installation
 
@@ -286,6 +297,8 @@ The seeder- & factory-location, can be specified via:
 The following values are assumed by default:
 - factory path: `src/database/factories/**/*{.ts,.js}`
 - seed path: `src/database/seeds/**/*{.ts,.js}`
+
+Note: When seeder paths are configured as **glob patterns**, the paths are resolved and sorted in alphabetical order using filenames. This helps to ensure that the seeders are executed in the correct order.
 
 `data-source.ts`
 

--- a/src/seeder/utils/file-path.ts
+++ b/src/seeder/utils/file-path.ts
@@ -1,6 +1,7 @@
 /* istanbul ignore next */
-import path from 'path';
+import type { LocatorInfo } from 'locter';
 import { locateMany } from 'locter';
+import path from 'path';
 
 export async function resolveFilePatterns(
     filesPattern: string[],
@@ -12,7 +13,7 @@ export async function resolveFilePatterns(
             ...(root ? { path: root } : {}),
             ignore: ['**/*.d.ts'],
         },
-    ).then((files) => files.map((el) => path.join(el.path, el.name + el.extension)));
+    ).then(buildFilePathname);
 }
 
 export function resolveFilePaths(
@@ -24,4 +25,14 @@ export function resolveFilePaths(
             filePath :
             path.resolve(root || process.cwd(), filePath)
     ));
+}
+
+/**
+ * Exported only for testing purposes
+ */
+export function buildFilePathname(files: LocatorInfo[]) {
+    return (
+        // sorting by name so that we can define the order of execution using file names
+        files.sort((a, b) => (a.name > b.name ? 1 : -1)).map((el) => path.join(el.path, el.name + el.extension))
+    );
 }

--- a/test/unit/seeder/utils/file-path.spec.ts
+++ b/test/unit/seeder/utils/file-path.spec.ts
@@ -1,0 +1,31 @@
+import { buildFilePathname } from '../../../../src/seeder/utils/file-path';
+
+describe('src/seeder/utils/file-path.ts', function () {
+    describe('buildFilePathname', function () {
+        it('should build file path name', function () {
+            const files = [
+                {
+                    path: '/path/to/dir',
+                    name: '2_file',
+                    extension: '.ts',
+                },
+                {
+                    path: '/path/to/dir',
+                    name: '1_file',
+                    extension: '.ts',
+                },
+                {
+                    path: '/path/to/dir',
+                    name: '0_file',
+                    extension: '.ts',
+                },
+            ];
+            const result = buildFilePathname(files);
+            expect(result).toEqual([
+                '/path/to/dir/0_file.ts',
+                '/path/to/dir/1_file.ts',
+                '/path/to/dir/2_file.ts',
+            ]);
+        });
+    });
+});


### PR DESCRIPTION
## Context

See > https://github.com/tada5hi/typeorm-extension/issues/544

Although I mentioned this should work along with `parallelExecution: false` I found that it could work regardless the value of that configuration. Sorting by filename would not affect the parallel execution.

