### PR TITLE
fix(seeder): ensure SeederExecutor properly sorts seed files on fileName

### DIFF
--- a/src/seeder/executor.ts
+++ b/src/seeder/executor.ts
@@ -213,7 +213,7 @@ export class SeederExecutor {
                 typeof a.fileName !== 'undefined' &&
                 typeof b.fileName !== 'undefined'
             ) {
-                return a.name > b.name ? 1 : -1;
+                return a.fileName > b.fileName ? 1 : -1;
             }
 
             return a.timestamp - b.timestamp;


### PR DESCRIPTION
Seed files are expected to be run in `fileName` order, same as migrations.

`SeederExecutor.buildEntities` method in place uses the `name` attribute (equal to `className`) to sort files.

Given the two files:
1. `001-customers.seed.ts`, exporting a `CustomersSeeder` class
2. `002-contracts.seed.ts, exporting a `ContractsSeeder` class

And given that the `ContractsSeeder` tries to fetch `Customer` entities, the `seed:run` command will fail when sorting seeds by `className`.

This pull request changes the sort call to use the `fileName` attribute instead.
