### PR TITLE
chore(seeder): add support for loading factory exports from modules

### DIFF
--- a/src/seeder/factory/utils.ts
+++ b/src/seeder/factory/utils.ts
@@ -56,7 +56,7 @@ export async function prepareSeederFactories(
         for (let i = 0; i < factoryFiles.length; i++) {
             const moduleExports = await load(factoryFiles[i]);
             const moduleDefault = getModuleExport(moduleExports);
-            const factory = moduleDefault.value;
+            const factory: SeederFactoryItem = moduleDefault.value;
 
             if (factory) {
                 factoryManager.set(


### PR DESCRIPTION
This PR fixes the issue where factories don't get loaded when referenced using a file match pattern.

Example
```javascript
{ factories: ['src/database/factories/**/*.factory.{ts,js}'] }
```