### PR TITLE
docs: correct node_modules path in v3 migration guide

### DIFF
--- a/docs/guide/migration-guide-v3.md
+++ b/docs/guide/migration-guide-v3.md
@@ -9,16 +9,16 @@ This the migration guide for upgrading from **v2** to **v3**.
 **Old**
 
 ```shell
-ts-node ./node-modules/typeorm-extension/dist/cli/index.js 
+ts-node ./node_modules/typeorm-extension/dist/cli/index.js 
 ```
 
 **New**
 ```shell
 // CommonJS
-ts-node ./node-modules/typeorm-extension/bin/cli.cjs 
+ts-node ./node_modules/typeorm-extension/bin/cli.cjs 
 
 // ESM
-ts-node-esm ./node-modules/typeorm-extension/bin/cli.mjs
+ts-node-esm ./node_modules/typeorm-extension/bin/cli.mjs
 ```
 
 ### General


### PR DESCRIPTION
This typo tripped me up when I copy pasted from the docs.