### PR TITLE
feat(postgres): allow schema creation for postgres

### DIFF
--- a/src/database/driver/postgres.ts
+++ b/src/database/driver/postgres.ts
@@ -24,6 +24,7 @@ export async function createSimplePostgresConnection(
         user: options.user,
         password: options.password,
         ssl: options.ssl,
+        schema: options.schema,
         ...(options.extra ? options.extra : {}),
     };
 
@@ -93,8 +94,12 @@ export async function createPostgresDatabase(
     const result = await executeSimplePostgresQuery(connection, query);
 
     if (typeof options.schema === 'string' && options.schema !== 'public') {
+        const schemaConnection = await createSimplePostgresConnection(driver, options, {
+            ...context,
+            initialDatabase: options.database,
+        });
         const schemaQuery = `CREATE SCHEMA IF NOT EXISTS "${options.schema}"`;
-        await executeSimplePostgresQuery(connection, schemaQuery);
+        await executeSimplePostgresQuery(schemaConnection, schemaQuery);
     }
 
     if (context.synchronize) {

--- a/src/database/driver/postgres.ts
+++ b/src/database/driver/postgres.ts
@@ -90,8 +90,12 @@ export async function createPostgresDatabase(
     if (typeof options.characterSet === 'string') {
         query += ` WITH ENCODING '${options.characterSet}'`;
     }
-
     const result = await executeSimplePostgresQuery(connection, query);
+
+    if (typeof options.schema === 'string' && options.schema !== 'public') {
+        const schemaQuery = `CREATE SCHEMA IF NOT EXISTS "${options.schema}"`;
+        await executeSimplePostgresQuery(connection, schemaQuery);
+    }
 
     if (context.synchronize) {
         await synchronizeDatabaseSchema(context.options);

--- a/src/database/driver/type.ts
+++ b/src/database/driver/type.ts
@@ -18,6 +18,9 @@ export type DriverOptions = {
     charset?: string,
     characterSet?: string,
 
+    // postgres specific
+    schema?: string
+
     extra?: {
         [key: string]: any
     }

--- a/src/database/driver/utils/build.ts
+++ b/src/database/driver/utils/build.ts
@@ -41,5 +41,6 @@ export function buildDriverOptions(options: DataSourceOptions): DriverOptions {
         ...(driverOptions.serviceName ? { serviceName: driverOptions.serviceName } : {}),
         ...(options.extra ? { extra: options.extra } : {}),
         ...(driverOptions.domain ? { domain: driverOptions.domain } : {}),
+        ...(driverOptions.schema ? { schema: driverOptions.schema } : {}),
     };
 }


### PR DESCRIPTION
hello,

we are facing an issue during database creation, we are not using the `public` schema of database in postgres. 

I reported this earlier: https://github.com/tada5hi/typeorm-extension/issues/264#issuecomment-2493846201

This change introduces the possibility the creation of schema if that's provided.

I published a [prerelease version](https://www.npmjs.com/package/@oroce/typeorm-extension) to npm to test this change, it works pretty well.