### PR TITLE
feat!: support typeorm 1.x and drop 0.3.x peer dep

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -35,6 +35,8 @@ The CLI is a *thin* layer — every command just calls a function from the publi
 
 `src/database/methods/create/module.ts` (and its `drop` / `check` siblings) own a single `switch` over `context.options.type` that maps each TypeORM `DatabaseType` to a driver-specific function in `src/database/driver/<driver>.ts`. There is no plugin registry — driver support is a closed set known at build time. Adding a driver = adding a file in `database/driver/` + adding a `case`. Keep this pattern; do not introduce a registry abstraction.
 
+The peer-dep range is `typeorm ^1.0.0`. TypeORM 0.3 is **not** supported on `typeorm-extension` v4+ — stay on `typeorm-extension` v3 if you need it. TypeORM 1.0 also removed the legacy `sqlite` driver (only `better-sqlite3` remains) and renamed deep types like `PostgresConnectionOptions` → `PostgresDataSourceOptions`; the code is already migrated.
+
 ### 2. Operations bypass `DataSource.initialize()`
 
 `createDatabase` / `dropDatabase` cannot use a TypeORM `DataSource`, because the database might not exist yet. Each driver file opens a *raw* native client (e.g. `pg.Client`, `mysql2.createConnection`) using credentials extracted from the data-source options, runs the SQL, and closes the connection. The TypeORM `Driver` object is used only for its connector reference (`driver.postgres`, `driver.mysql`) — never `.connect()`d.

--- a/.agents/structure.md
+++ b/.agents/structure.md
@@ -72,7 +72,7 @@ typeorm-extension/
 
 | Dependency           | Role                                                                                          |
 |----------------------|-----------------------------------------------------------------------------------------------|
-| `typeorm` (peer)     | The ORM being extended. Pinned to `~0.3.0`.                                                   |
+| `typeorm` (peer)     | The ORM being extended. Requires `^1.0.0` (TypeORM 0.3 is no longer supported).                |
 | `@faker-js/faker`    | Optional peer — only required when using `SeederFactory`.                                     |
 | `rapiq`              | JSON:API query parser. `query/module.ts` is a thin TypeORM-flavoured adapter on top of it.    |
 | `locter`             | Glob + file loading (used to discover data-source / seed / factory files).                    |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 A TypeScript library that extends [TypeORM](https://typeorm.io) with:
 
-- `create` / `drop` databases across all supported drivers (Postgres, MySQL/MariaDB, MongoDB, MSSQL, Oracle, SQLite/better-sqlite3, CockroachDB).
+- `create` / `drop` databases across all supported drivers (Postgres, MySQL/MariaDB, MongoDB, MSSQL, Oracle, better-sqlite3, CockroachDB). Note: TypeORM 1.0 removed the legacy `sqlite` driver — use `better-sqlite3`.
 - A seeder/factory system (similar to Laravel) backed by `@faker-js/faker`.
 - A data-source registry with auto-discovery and lazy initialization.
 - A JSON:API-style query parameter parser that applies `fields`, `filters`, `relations`, `sort`, and `page` onto a `SelectQueryBuilder`.

--- a/docs/guide/migration-guide-v4.md
+++ b/docs/guide/migration-guide-v4.md
@@ -1,6 +1,6 @@
 # Upgrading to v4
 
-This is the migration guide for upgrading from **v3** to **v4**. v4 modernizes the toolchain (ESM-only, Node ≥ 22, new bundler / test runner / linter); the typeorm peer-dep bump to `^1.0.0` is a separate follow-up release once typeorm 1.0 ships.
+This is the migration guide for upgrading from **v3** to **v4**. v4 modernizes the toolchain (ESM-only, Node ≥ 22, new bundler / test runner / linter) **and** moves the typeorm peer-dep to `^1.0.0`. TypeORM `0.3.x` is no longer supported — stay on `typeorm-extension` v3 if you need it.
 
 ## Breaking Changes
 
@@ -40,7 +40,23 @@ You can use any TypeScript-aware loader (`tsx`, Node's `--experimental-strip-typ
 
 ### Peer dependency: TypeORM
 
-`peerDependencies.typeorm` is still `~0.3.0` in this release — typeorm 1.0 hasn't shipped yet. v4 is the **toolchain-modernization** half of the v3 → v4 jump; the peer-dep bump to `^1.0.0` will land in a follow-up release once typeorm 1.0 is stable. No TypeORM API changes are required by this v4 upgrade itself.
+| v3 | v4 |
+|---|---|
+| `typeorm ~0.3.0` | `typeorm ^1.0.0` |
+
+TypeORM `0.3.x` is **not** supported on `typeorm-extension` v4+. Pick the row that fits you:
+
+- Already on TypeORM `1.0`: upgrade to `typeorm-extension` v4.
+- Still on TypeORM `0.3.x`: stay on `typeorm-extension` v3 until you can migrate the rest of your app to TypeORM `1.0`.
+
+The TypeORM 1.0 upstream changes that affect `typeorm-extension` consumers:
+
+- **`sqlite` driver removed** — TypeORM 1.0 dropped the `sqlite` package; only `better-sqlite3` is supported. `typeorm-extension` follows suit and only handles `better-sqlite3` in `createDatabase` / `dropDatabase` / `TYPEORM_CONNECTION`.
+- **MongoDB**: requires `mongodb` `^7.0.0`.
+- **MySQL**: only the `mysql2` package is supported (the legacy `mysql` package is removed).
+- **Node.js**: TypeORM 1.0 requires Node `^20.19.0 || ^22.13.0 || >=24.11.0`. `typeorm-extension` v4 already requires Node `>=22.0.0`.
+
+See the [TypeORM 1.0 release notes](https://typeorm.io/docs/releases/1.0/release-notes/) for the full list of upstream breaking changes.
 
 ## Internal Toolchain (no consumer impact)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
             },
             "peerDependencies": {
                 "@faker-js/faker": ">=8.4.1",
-                "typeorm": ">=0.3.0 <2"
+                "typeorm": "^1.0.0"
             }
         },
         "node_modules/@algolia/abtesting": {
@@ -1276,6 +1276,22 @@
                 "node": ">=12"
             }
         },
+        "node_modules/@esbuild/netbsd-arm64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+            "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+            "cpu": [
+                "arm64"
+            ],
+            "extraneous": true,
+            "license": "MIT",
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/@esbuild/netbsd-x64": {
             "version": "0.21.5",
             "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
@@ -1293,6 +1309,22 @@
                 "node": ">=12"
             }
         },
+        "node_modules/@esbuild/openbsd-arm64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+            "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+            "cpu": [
+                "arm64"
+            ],
+            "extraneous": true,
+            "license": "MIT",
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/@esbuild/openbsd-x64": {
             "version": "0.21.5",
             "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
@@ -1308,6 +1340,22 @@
             ],
             "engines": {
                 "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/openharmony-arm64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+            "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+            "cpu": [
+                "arm64"
+            ],
+            "extraneous": true,
+            "license": "MIT",
+            "os": [
+                "openharmony"
+            ],
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/sunos-x64": {
@@ -4274,46 +4322,6 @@
                 "node": ">=20"
             }
         },
-        "node_modules/cliui/node_modules/emoji-regex": {
-            "version": "10.6.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
-            "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-            "license": "MIT"
-        },
-        "node_modules/cliui/node_modules/string-width": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-            "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-            "license": "MIT",
-            "dependencies": {
-                "emoji-regex": "^10.3.0",
-                "get-east-asian-width": "^1.0.0",
-                "strip-ansi": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/cliui/node_modules/wrap-ansi": {
-            "version": "9.0.2",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
-            "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^6.2.1",
-                "string-width": "^7.0.0",
-                "strip-ansi": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-            }
-        },
         "node_modules/color-convert": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -4696,6 +4704,12 @@
             "integrity": "sha512-GkcBt6YYAw9SxFWn+xVar4cLVGlXVuswwtRLBozi2zp0GjXs4ZnOrqV4zbXzg35n7w81hCkyJNYicgXlVHAmBA==",
             "dev": true,
             "license": "ISC"
+        },
+        "node_modules/emoji-regex": {
+            "version": "10.6.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+            "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+            "license": "MIT"
         },
         "node_modules/emoji-regex-xs": {
             "version": "1.0.0",
@@ -7591,6 +7605,23 @@
                 "safe-buffer": "~5.2.0"
             }
         },
+        "node_modules/string-width": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+            "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^10.3.0",
+                "get-east-asian-width": "^1.0.0",
+                "strip-ansi": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/stringify-entities": {
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
@@ -8449,6 +8480,374 @@
                 }
             }
         },
+        "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+            "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "extraneous": true,
+            "license": "MIT",
+            "os": [
+                "aix"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/android-arm": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+            "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+            "cpu": [
+                "arm"
+            ],
+            "extraneous": true,
+            "license": "MIT",
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+            "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+            "cpu": [
+                "arm64"
+            ],
+            "extraneous": true,
+            "license": "MIT",
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/android-x64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+            "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+            "cpu": [
+                "x64"
+            ],
+            "extraneous": true,
+            "license": "MIT",
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+            "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "extraneous": true,
+            "license": "MIT",
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+            "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+            "cpu": [
+                "x64"
+            ],
+            "extraneous": true,
+            "license": "MIT",
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+            "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "extraneous": true,
+            "license": "MIT",
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+            "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+            "cpu": [
+                "x64"
+            ],
+            "extraneous": true,
+            "license": "MIT",
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+            "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+            "cpu": [
+                "arm"
+            ],
+            "extraneous": true,
+            "license": "MIT",
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+            "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+            "cpu": [
+                "arm64"
+            ],
+            "extraneous": true,
+            "license": "MIT",
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+            "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+            "cpu": [
+                "ia32"
+            ],
+            "extraneous": true,
+            "license": "MIT",
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+            "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+            "cpu": [
+                "loong64"
+            ],
+            "extraneous": true,
+            "license": "MIT",
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+            "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+            "cpu": [
+                "mips64el"
+            ],
+            "extraneous": true,
+            "license": "MIT",
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+            "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+            "cpu": [
+                "ppc64"
+            ],
+            "extraneous": true,
+            "license": "MIT",
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+            "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+            "cpu": [
+                "riscv64"
+            ],
+            "extraneous": true,
+            "license": "MIT",
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+            "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+            "cpu": [
+                "s390x"
+            ],
+            "extraneous": true,
+            "license": "MIT",
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+            "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+            "cpu": [
+                "x64"
+            ],
+            "extraneous": true,
+            "license": "MIT",
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+            "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+            "cpu": [
+                "x64"
+            ],
+            "extraneous": true,
+            "license": "MIT",
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+            "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+            "cpu": [
+                "x64"
+            ],
+            "extraneous": true,
+            "license": "MIT",
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+            "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+            "cpu": [
+                "x64"
+            ],
+            "extraneous": true,
+            "license": "MIT",
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+            "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+            "cpu": [
+                "arm64"
+            ],
+            "extraneous": true,
+            "license": "MIT",
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+            "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+            "cpu": [
+                "ia32"
+            ],
+            "extraneous": true,
+            "license": "MIT",
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+            "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+            "cpu": [
+                "x64"
+            ],
+            "extraneous": true,
+            "license": "MIT",
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/vitest/node_modules/@oxc-project/types": {
             "version": "0.130.0",
             "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.130.0.tgz",
@@ -8768,6 +9167,48 @@
                 }
             }
         },
+        "node_modules/vitest/node_modules/esbuild": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+            "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+            "extraneous": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "bin": {
+                "esbuild": "bin/esbuild"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "optionalDependencies": {
+                "@esbuild/aix-ppc64": "0.28.0",
+                "@esbuild/android-arm": "0.28.0",
+                "@esbuild/android-arm64": "0.28.0",
+                "@esbuild/android-x64": "0.28.0",
+                "@esbuild/darwin-arm64": "0.28.0",
+                "@esbuild/darwin-x64": "0.28.0",
+                "@esbuild/freebsd-arm64": "0.28.0",
+                "@esbuild/freebsd-x64": "0.28.0",
+                "@esbuild/linux-arm": "0.28.0",
+                "@esbuild/linux-arm64": "0.28.0",
+                "@esbuild/linux-ia32": "0.28.0",
+                "@esbuild/linux-loong64": "0.28.0",
+                "@esbuild/linux-mips64el": "0.28.0",
+                "@esbuild/linux-ppc64": "0.28.0",
+                "@esbuild/linux-riscv64": "0.28.0",
+                "@esbuild/linux-s390x": "0.28.0",
+                "@esbuild/linux-x64": "0.28.0",
+                "@esbuild/netbsd-arm64": "0.28.0",
+                "@esbuild/netbsd-x64": "0.28.0",
+                "@esbuild/openbsd-arm64": "0.28.0",
+                "@esbuild/openbsd-x64": "0.28.0",
+                "@esbuild/openharmony-arm64": "0.28.0",
+                "@esbuild/sunos-x64": "0.28.0",
+                "@esbuild/win32-arm64": "0.28.0",
+                "@esbuild/win32-ia32": "0.28.0",
+                "@esbuild/win32-x64": "0.28.0"
+            }
+        },
         "node_modules/vitest/node_modules/rolldown": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.1.tgz",
@@ -8977,6 +9418,23 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/wrap-ansi": {
+            "version": "9.0.2",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+            "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^6.2.1",
+                "string-width": "^7.0.0",
+                "strip-ansi": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
         "node_modules/wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -9042,29 +9500,6 @@
             "license": "ISC",
             "engines": {
                 "node": "^20.19.0 || ^22.12.0 || >=23"
-            }
-        },
-        "node_modules/yargs/node_modules/emoji-regex": {
-            "version": "10.6.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
-            "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-            "license": "MIT"
-        },
-        "node_modules/yargs/node_modules/string-width": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-            "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-            "license": "MIT",
-            "dependencies": {
-                "emoji-regex": "^10.3.0",
-                "get-east-asian-width": "^1.0.0",
-                "strip-ansi": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/yocto-queue": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
                 "eslint-plugin-vue": "^10.9.1",
                 "husky": "^9.1.7",
                 "tsdown": "^0.21.10",
-                "typeorm": "^0.3.27",
+                "typeorm": "^1.0.0",
                 "typescript": "^6.0.3",
                 "typescript-eslint": "^8.59.2",
                 "unplugin-swc": "^1.5.9",
@@ -48,7 +48,7 @@
             },
             "peerDependencies": {
                 "@faker-js/faker": ">=8.4.1",
-                "typeorm": "~0.3.0"
+                "typeorm": ">=0.3.0 <2"
             }
         },
         "node_modules/@algolia/abtesting": {
@@ -1276,22 +1276,6 @@
                 "node": ">=12"
             }
         },
-        "node_modules/@esbuild/netbsd-arm64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
-            "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
-            "cpu": [
-                "arm64"
-            ],
-            "extraneous": true,
-            "license": "MIT",
-            "os": [
-                "netbsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
         "node_modules/@esbuild/netbsd-x64": {
             "version": "0.21.5",
             "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
@@ -1309,22 +1293,6 @@
                 "node": ">=12"
             }
         },
-        "node_modules/@esbuild/openbsd-arm64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
-            "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
-            "cpu": [
-                "arm64"
-            ],
-            "extraneous": true,
-            "license": "MIT",
-            "os": [
-                "openbsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
         "node_modules/@esbuild/openbsd-x64": {
             "version": "0.21.5",
             "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
@@ -1340,22 +1308,6 @@
             ],
             "engines": {
                 "node": ">=12"
-            }
-        },
-        "node_modules/@esbuild/openharmony-arm64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
-            "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
-            "cpu": [
-                "arm64"
-            ],
-            "extraneous": true,
-            "license": "MIT",
-            "os": [
-                "openharmony"
-            ],
-            "engines": {
-                "node": ">=18"
             }
         },
         "node_modules/@esbuild/sunos-x64": {
@@ -1654,24 +1606,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/@isaacs/cliui": {
-            "version": "8.0.2",
-            "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
-            "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "string-width": "^5.1.2",
-                "string-width-cjs": "npm:string-width@^4.2.0",
-                "strip-ansi": "^7.0.1",
-                "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-                "wrap-ansi": "^8.1.0",
-                "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
         "node_modules/@jridgewell/gen-mapping": {
             "version": "0.3.13",
             "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1784,17 +1718,6 @@
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/Boshen"
-            }
-        },
-        "node_modules/@pkgjs/parseargs": {
-            "version": "0.11.0",
-            "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
-            "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "engines": {
-                "node": ">=14"
             }
         },
         "node_modules/@quansync/fs": {
@@ -3899,16 +3822,6 @@
                 "node": ">=14"
             }
         },
-        "node_modules/app-root-path": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-3.1.0.tgz",
-            "integrity": "sha512-biN3PwB2gUtjaYy/isrU3aNWI5w+fAfvHkSvCKeQGxhmYpwKFUxudR3Yya+KqVRHBmEDYh+/lTozYCFbmzX4nA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 6.0.0"
-            }
-        },
         "node_modules/argparse": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -4012,22 +3925,6 @@
                 "@jridgewell/trace-mapping": "^0.3.31",
                 "estree-walker": "^3.0.3",
                 "js-tokens": "^10.0.0"
-            }
-        },
-        "node_modules/available-typed-arrays": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
-            "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "possible-typed-array-names": "^1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/balanced-match": {
@@ -4235,56 +4132,6 @@
                 "node": ">=20.19.0"
             }
         },
-        "node_modules/call-bind": {
-            "version": "1.0.9",
-            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
-            "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind-apply-helpers": "^1.0.2",
-                "es-define-property": "^1.0.1",
-                "get-intrinsic": "^1.3.0",
-                "set-function-length": "^1.2.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/call-bind-apply-helpers": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-            "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "es-errors": "^1.3.0",
-                "function-bind": "^1.1.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/call-bound": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
-            "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind-apply-helpers": "^1.0.2",
-                "get-intrinsic": "^1.3.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/callsites": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -4473,6 +4320,7 @@
             "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "color-name": "~1.1.4"
             },
@@ -4485,7 +4333,8 @@
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/comma-separated-tokens": {
             "version": "2.0.3",
@@ -4754,24 +4603,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/define-data-property": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
-            "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "es-define-property": "^1.0.0",
-                "es-errors": "^1.3.0",
-                "gopd": "^1.0.1"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/defu": {
             "version": "6.1.7",
             "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
@@ -4832,19 +4663,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/dotenv": {
-            "version": "16.6.1",
-            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-            "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://dotenvx.com"
-            }
-        },
         "node_modules/dts-resolver": {
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/dts-resolver/-/dts-resolver-2.1.3.tgz",
@@ -4866,28 +4684,6 @@
                 }
             }
         },
-        "node_modules/dunder-proto": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-            "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind-apply-helpers": "^1.0.1",
-                "es-errors": "^1.3.0",
-                "gopd": "^1.2.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/eastasianwidth": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-            "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/ebec": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/ebec/-/ebec-2.3.0.tgz",
@@ -4900,13 +4696,6 @@
             "integrity": "sha512-GkcBt6YYAw9SxFWn+xVar4cLVGlXVuswwtRLBozi2zp0GjXs4ZnOrqV4zbXzg35n7w81hCkyJNYicgXlVHAmBA==",
             "dev": true,
             "license": "ISC"
-        },
-        "node_modules/emoji-regex": {
-            "version": "9.2.2",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-            "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/emoji-regex-xs": {
             "version": "1.0.0",
@@ -4988,45 +4777,12 @@
                 "is-arrayish": "^0.2.1"
             }
         },
-        "node_modules/es-define-property": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-            "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/es-errors": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
         "node_modules/es-module-lexer": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
             "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/es-object-atoms": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-            "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "es-errors": "^1.3.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
         },
         "node_modules/es-toolkit": {
             "version": "1.46.1",
@@ -5613,39 +5369,6 @@
                 "tabbable": "^6.4.0"
             }
         },
-        "node_modules/for-each": {
-            "version": "0.3.5",
-            "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
-            "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "is-callable": "^1.2.7"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/foreground-child": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
-            "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "cross-spawn": "^7.0.6",
-                "signal-exit": "^4.0.1"
-            },
-            "engines": {
-                "node": ">=14"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
         "node_modules/fs-constants": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
@@ -5668,16 +5391,6 @@
                 "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
             }
         },
-        "node_modules/function-bind": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-            "dev": true,
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/get-caller-file": {
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -5697,45 +5410,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/get-intrinsic": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-            "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bind-apply-helpers": "^1.0.2",
-                "es-define-property": "^1.0.1",
-                "es-errors": "^1.3.0",
-                "es-object-atoms": "^1.1.1",
-                "function-bind": "^1.1.2",
-                "get-proto": "^1.0.1",
-                "gopd": "^1.2.0",
-                "has-symbols": "^1.1.0",
-                "hasown": "^2.0.2",
-                "math-intrinsics": "^1.1.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/get-proto": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-            "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "dunder-proto": "^1.0.1",
-                "es-object-atoms": "^1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
             }
         },
         "node_modules/get-tsconfig": {
@@ -5776,28 +5450,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/glob": {
-            "version": "10.5.0",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-            "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "foreground-child": "^3.1.0",
-                "jackspeak": "^3.1.2",
-                "minimatch": "^9.0.4",
-                "minipass": "^7.1.2",
-                "package-json-from-dist": "^1.0.0",
-                "path-scurry": "^1.11.1"
-            },
-            "bin": {
-                "glob": "dist/esm/bin.mjs"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
         "node_modules/glob-parent": {
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -5809,39 +5461,6 @@
             },
             "engines": {
                 "node": ">=10.13.0"
-            }
-        },
-        "node_modules/glob/node_modules/balanced-match": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/glob/node_modules/brace-expansion": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-            "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0"
-            }
-        },
-        "node_modules/glob/node_modules/minimatch": {
-            "version": "9.0.9",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^2.0.2"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/global-directory": {
@@ -5874,19 +5493,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/gopd": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-            "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/has-flag": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -5895,61 +5501,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/has-property-descriptors": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
-            "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "es-define-property": "^1.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/has-symbols": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-            "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/has-tostringtag": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-            "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "has-symbols": "^1.0.3"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/hasown": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-            "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "function-bind": "^1.1.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
             }
         },
         "node_modules/hast-util-to-html": {
@@ -6181,19 +5732,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/is-callable": {
-            "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
-            "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/is-extglob": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -6209,6 +5747,7 @@
             "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -6258,22 +5797,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/is-typed-array": {
-            "version": "1.1.15",
-            "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
-            "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "which-typed-array": "^1.1.16"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/is-what": {
             "version": "5.5.0",
             "resolved": "https://registry.npmjs.org/is-what/-/is-what-5.5.0.tgz",
@@ -6286,13 +5809,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/mesqueeb"
             }
-        },
-        "node_modules/isarray": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-            "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/isexe": {
             "version": "2.0.0",
@@ -6338,22 +5854,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/jackspeak": {
-            "version": "3.4.3",
-            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-            "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "@isaacs/cliui": "^8.0.2"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            },
-            "optionalDependencies": {
-                "@pkgjs/parseargs": "^0.11.0"
             }
         },
         "node_modules/jiti": {
@@ -6786,13 +6286,6 @@
                 "tslib": "^2.0.3"
             }
         },
-        "node_modules/lru-cache": {
-            "version": "10.4.3",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-            "dev": true,
-            "license": "ISC"
-        },
         "node_modules/magic-string": {
             "version": "0.30.21",
             "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -6837,16 +6330,6 @@
             "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/math-intrinsics": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-            "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            }
         },
         "node_modules/mdast-util-to-hast": {
             "version": "13.2.1",
@@ -7050,16 +6533,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/minipass": {
-            "version": "7.1.3",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-            "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
-            }
-        },
         "node_modules/minisearch": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-7.2.0.tgz",
@@ -7247,13 +6720,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/package-json-from-dist": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
-            "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-            "dev": true,
-            "license": "BlueOak-1.0.0"
-        },
         "node_modules/package-manager-detector": {
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
@@ -7325,23 +6791,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/path-scurry": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-            "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "lru-cache": "^10.2.0",
-                "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.18"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
         "node_modules/pathe": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -7384,16 +6833,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=4"
-            }
-        },
-        "node_modules/possible-typed-array-names": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
-            "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
             }
         },
         "node_modules/postcss": {
@@ -7676,6 +7115,7 @@
             "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -7976,45 +7416,6 @@
                 "node": ">=10"
             }
         },
-        "node_modules/set-function-length": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
-            "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "define-data-property": "^1.1.4",
-                "es-errors": "^1.3.0",
-                "function-bind": "^1.1.2",
-                "get-intrinsic": "^1.2.4",
-                "gopd": "^1.0.1",
-                "has-property-descriptors": "^1.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/sha.js": {
-            "version": "2.4.12",
-            "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
-            "integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
-            "dev": true,
-            "license": "(MIT AND BSD-3-Clause)",
-            "dependencies": {
-                "inherits": "^2.0.4",
-                "safe-buffer": "^5.2.1",
-                "to-buffer": "^1.2.0"
-            },
-            "bin": {
-                "sha.js": "bin.js"
-            },
-            "engines": {
-                "node": ">= 0.10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/shebang-command": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -8061,19 +7462,6 @@
             "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
             "dev": true,
             "license": "ISC"
-        },
-        "node_modules/signal-exit": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-            "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": ">=14"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
         },
         "node_modules/simple-concat": {
             "version": "1.0.1",
@@ -8203,70 +7591,6 @@
                 "safe-buffer": "~5.2.0"
             }
         },
-        "node_modules/string-width": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-            "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "eastasianwidth": "^0.2.0",
-                "emoji-regex": "^9.2.2",
-                "strip-ansi": "^7.0.1"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/string-width-cjs": {
-            "name": "string-width",
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/string-width-cjs/node_modules/ansi-regex": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/string-width-cjs/node_modules/emoji-regex": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/string-width-cjs/node_modules/strip-ansi": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/stringify-entities": {
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
@@ -8295,30 +7619,6 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-            }
-        },
-        "node_modules/strip-ansi-cjs": {
-            "name": "strip-ansi",
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/strip-indent": {
@@ -8449,21 +7749,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=14.0.0"
-            }
-        },
-        "node_modules/to-buffer": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
-            "integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "isarray": "^2.0.5",
-                "safe-buffer": "^5.2.1",
-                "typed-array-buffer": "^1.0.3"
-            },
-            "engines": {
-                "node": ">= 0.4"
             }
         },
         "node_modules/to-regex-range": {
@@ -8610,43 +7895,23 @@
                 "node": ">= 0.8.0"
             }
         },
-        "node_modules/typed-array-buffer": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
-            "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "call-bound": "^1.0.3",
-                "es-errors": "^1.3.0",
-                "is-typed-array": "^1.1.14"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
         "node_modules/typeorm": {
-            "version": "0.3.30",
-            "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.30.tgz",
-            "integrity": "sha512-8T35PzjefOdqc2ZR9mwLQj0pUGp6lQhMbK2EvVMwJVJWlaoHm0v/Q6dThNOZkFchD+0yMg8gwjKM28ePiLSXSQ==",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-1.0.0.tgz",
+            "integrity": "sha512-2mSKNqucP8vo+xQLP59xlHUcqLvG6qajxA7q7tnhJgeZjTrA6lK/Ar7LRyiAxdXhyXmGbIPsArPmcUB9Xg+M7w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@sqltools/formatter": "^1.2.5",
                 "ansis": "^4.2.0",
-                "app-root-path": "^3.1.0",
-                "buffer": "^6.0.3",
                 "dayjs": "^1.11.20",
                 "debug": "^4.4.3",
                 "dedent": "^1.7.2",
-                "dotenv": "^16.6.1",
-                "glob": "^10.5.0",
                 "reflect-metadata": "^0.2.2",
-                "sha.js": "^2.4.12",
                 "sql-highlight": "^6.1.0",
+                "tinyglobby": "^0.2.16",
                 "tslib": "^2.8.1",
-                "uuid": "^11.1.1",
-                "yargs": "^17.7.2"
+                "yargs": "^18.0.0"
             },
             "bin": {
                 "typeorm": "cli.js",
@@ -8654,28 +7919,27 @@
                 "typeorm-ts-node-esm": "cli-ts-node-esm.js"
             },
             "engines": {
-                "node": ">=16.13.0"
+                "node": "^20.19.0 || ^22.13.0 || >=24.11.0"
             },
             "funding": {
                 "url": "https://opencollective.com/typeorm"
             },
             "peerDependencies": {
-                "@google-cloud/spanner": "^5.18.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
+                "@google-cloud/spanner": "^8.0.0",
                 "@sap/hana-client": "^2.14.22",
-                "better-sqlite3": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0",
+                "better-sqlite3": "^12.0.0",
                 "ioredis": "^5.0.4",
-                "mongodb": "^5.8.0 || ^6.0.0",
-                "mssql": "^9.1.1 || ^10.0.0 || ^11.0.0 || ^12.0.0",
-                "mysql2": "^2.2.5 || ^3.0.1",
+                "mongodb": "^7.0.0",
+                "mssql": "^12.0.0",
+                "mysql2": "^3.15.3",
                 "oracledb": "^6.3.0",
                 "pg": "^8.5.1",
                 "pg-native": "^3.0.0",
                 "pg-query-stream": "^4.0.0",
-                "redis": "^3.1.1 || ^4.0.0 || ^5.0.14",
+                "redis": "^5.0.0",
                 "sql.js": "^1.4.0",
-                "sqlite3": "^5.0.3",
-                "ts-node": "^10.7.0",
-                "typeorm-aurora-data-api-driver": "^2.0.0 || ^3.0.0"
+                "ts-node": "^10.9.2",
+                "typeorm-aurora-data-api-driver": "^3.0.0"
             },
             "peerDependenciesMeta": {
                 "@google-cloud/spanner": {
@@ -8717,163 +7981,12 @@
                 "sql.js": {
                     "optional": true
                 },
-                "sqlite3": {
-                    "optional": true
-                },
                 "ts-node": {
                     "optional": true
                 },
                 "typeorm-aurora-data-api-driver": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/typeorm/node_modules/ansi-regex": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/typeorm/node_modules/ansi-styles": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "color-convert": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/typeorm/node_modules/buffer": {
-            "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-            "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "base64-js": "^1.3.1",
-                "ieee754": "^1.2.1"
-            }
-        },
-        "node_modules/typeorm/node_modules/cliui": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-            "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "string-width": "^4.2.0",
-                "strip-ansi": "^6.0.1",
-                "wrap-ansi": "^7.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/typeorm/node_modules/emoji-regex": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/typeorm/node_modules/string-width": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/typeorm/node_modules/strip-ansi": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/typeorm/node_modules/wrap-ansi": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^4.0.0",
-                "string-width": "^4.1.0",
-                "strip-ansi": "^6.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-            }
-        },
-        "node_modules/typeorm/node_modules/yargs": {
-            "version": "17.7.2",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-            "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "cliui": "^8.0.1",
-                "escalade": "^3.1.1",
-                "get-caller-file": "^2.0.5",
-                "require-directory": "^2.1.1",
-                "string-width": "^4.2.3",
-                "y18n": "^5.0.5",
-                "yargs-parser": "^21.1.1"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/typeorm/node_modules/yargs-parser": {
-            "version": "21.1.1",
-            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-            "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": ">=12"
             }
         },
         "node_modules/typescript": {
@@ -9114,20 +8227,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/uuid": {
-            "version": "11.1.1",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
-            "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
-            "dev": true,
-            "funding": [
-                "https://github.com/sponsors/broofa",
-                "https://github.com/sponsors/ctavan"
-            ],
-            "license": "MIT",
-            "bin": {
-                "uuid": "dist/esm/bin/uuid"
-            }
-        },
         "node_modules/vfile": {
             "version": "6.0.3",
             "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
@@ -9348,374 +8447,6 @@
                 "vite": {
                     "optional": false
                 }
-            }
-        },
-        "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
-            "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
-            "cpu": [
-                "ppc64"
-            ],
-            "extraneous": true,
-            "license": "MIT",
-            "os": [
-                "aix"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/vitest/node_modules/@esbuild/android-arm": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
-            "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
-            "cpu": [
-                "arm"
-            ],
-            "extraneous": true,
-            "license": "MIT",
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/vitest/node_modules/@esbuild/android-arm64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
-            "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
-            "cpu": [
-                "arm64"
-            ],
-            "extraneous": true,
-            "license": "MIT",
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/vitest/node_modules/@esbuild/android-x64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
-            "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
-            "cpu": [
-                "x64"
-            ],
-            "extraneous": true,
-            "license": "MIT",
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
-            "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
-            "cpu": [
-                "arm64"
-            ],
-            "extraneous": true,
-            "license": "MIT",
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
-            "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
-            "cpu": [
-                "x64"
-            ],
-            "extraneous": true,
-            "license": "MIT",
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
-            "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
-            "cpu": [
-                "arm64"
-            ],
-            "extraneous": true,
-            "license": "MIT",
-            "os": [
-                "freebsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
-            "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
-            "cpu": [
-                "x64"
-            ],
-            "extraneous": true,
-            "license": "MIT",
-            "os": [
-                "freebsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/vitest/node_modules/@esbuild/linux-arm": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
-            "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
-            "cpu": [
-                "arm"
-            ],
-            "extraneous": true,
-            "license": "MIT",
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
-            "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
-            "cpu": [
-                "arm64"
-            ],
-            "extraneous": true,
-            "license": "MIT",
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
-            "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
-            "cpu": [
-                "ia32"
-            ],
-            "extraneous": true,
-            "license": "MIT",
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
-            "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
-            "cpu": [
-                "loong64"
-            ],
-            "extraneous": true,
-            "license": "MIT",
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
-            "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
-            "cpu": [
-                "mips64el"
-            ],
-            "extraneous": true,
-            "license": "MIT",
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
-            "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
-            "cpu": [
-                "ppc64"
-            ],
-            "extraneous": true,
-            "license": "MIT",
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
-            "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
-            "cpu": [
-                "riscv64"
-            ],
-            "extraneous": true,
-            "license": "MIT",
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
-            "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
-            "cpu": [
-                "s390x"
-            ],
-            "extraneous": true,
-            "license": "MIT",
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/vitest/node_modules/@esbuild/linux-x64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
-            "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
-            "cpu": [
-                "x64"
-            ],
-            "extraneous": true,
-            "license": "MIT",
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
-            "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
-            "cpu": [
-                "x64"
-            ],
-            "extraneous": true,
-            "license": "MIT",
-            "os": [
-                "netbsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
-            "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
-            "cpu": [
-                "x64"
-            ],
-            "extraneous": true,
-            "license": "MIT",
-            "os": [
-                "openbsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
-            "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
-            "cpu": [
-                "x64"
-            ],
-            "extraneous": true,
-            "license": "MIT",
-            "os": [
-                "sunos"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
-            "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
-            "cpu": [
-                "arm64"
-            ],
-            "extraneous": true,
-            "license": "MIT",
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
-            "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
-            "cpu": [
-                "ia32"
-            ],
-            "extraneous": true,
-            "license": "MIT",
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/vitest/node_modules/@esbuild/win32-x64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
-            "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
-            "cpu": [
-                "x64"
-            ],
-            "extraneous": true,
-            "license": "MIT",
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=18"
             }
         },
         "node_modules/vitest/node_modules/@oxc-project/types": {
@@ -10037,48 +8768,6 @@
                 }
             }
         },
-        "node_modules/vitest/node_modules/esbuild": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
-            "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
-            "extraneous": true,
-            "hasInstallScript": true,
-            "license": "MIT",
-            "bin": {
-                "esbuild": "bin/esbuild"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "optionalDependencies": {
-                "@esbuild/aix-ppc64": "0.28.0",
-                "@esbuild/android-arm": "0.28.0",
-                "@esbuild/android-arm64": "0.28.0",
-                "@esbuild/android-x64": "0.28.0",
-                "@esbuild/darwin-arm64": "0.28.0",
-                "@esbuild/darwin-x64": "0.28.0",
-                "@esbuild/freebsd-arm64": "0.28.0",
-                "@esbuild/freebsd-x64": "0.28.0",
-                "@esbuild/linux-arm": "0.28.0",
-                "@esbuild/linux-arm64": "0.28.0",
-                "@esbuild/linux-ia32": "0.28.0",
-                "@esbuild/linux-loong64": "0.28.0",
-                "@esbuild/linux-mips64el": "0.28.0",
-                "@esbuild/linux-ppc64": "0.28.0",
-                "@esbuild/linux-riscv64": "0.28.0",
-                "@esbuild/linux-s390x": "0.28.0",
-                "@esbuild/linux-x64": "0.28.0",
-                "@esbuild/netbsd-arm64": "0.28.0",
-                "@esbuild/netbsd-x64": "0.28.0",
-                "@esbuild/openbsd-arm64": "0.28.0",
-                "@esbuild/openbsd-x64": "0.28.0",
-                "@esbuild/openharmony-arm64": "0.28.0",
-                "@esbuild/sunos-x64": "0.28.0",
-                "@esbuild/win32-arm64": "0.28.0",
-                "@esbuild/win32-ia32": "0.28.0",
-                "@esbuild/win32-x64": "0.28.0"
-            }
-        },
         "node_modules/vitest/node_modules/rolldown": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.1.tgz",
@@ -10261,28 +8950,6 @@
                 "node": ">= 8"
             }
         },
-        "node_modules/which-typed-array": {
-            "version": "1.1.20",
-            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
-            "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "available-typed-arrays": "^1.0.7",
-                "call-bind": "^1.0.8",
-                "call-bound": "^1.0.4",
-                "for-each": "^0.3.5",
-                "get-proto": "^1.0.1",
-                "gopd": "^1.2.0",
-                "has-tostringtag": "^1.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/why-is-node-running": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -10308,104 +8975,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/wrap-ansi": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-            "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^6.1.0",
-                "string-width": "^5.0.1",
-                "strip-ansi": "^7.0.1"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-            }
-        },
-        "node_modules/wrap-ansi-cjs": {
-            "name": "wrap-ansi",
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^4.0.0",
-                "string-width": "^4.1.0",
-                "strip-ansi": "^6.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-            }
-        },
-        "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "color-convert": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/wrap-ansi-cjs/node_modules/string-width": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/wrappy": {

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     },
     "peerDependencies": {
         "@faker-js/faker": ">=8.4.1",
-        "typeorm": "~0.3.0"
+        "typeorm": "^1.0.0"
     },
     "devDependencies": {
         "@faker-js/faker": "^9.9.0",
@@ -90,7 +90,7 @@
         "eslint-plugin-vue": "^10.9.1",
         "husky": "^9.1.7",
         "tsdown": "^0.21.10",
-        "typeorm": "^0.3.27",
+        "typeorm": "^1.0.0",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.59.2",
         "unplugin-swc": "^1.5.9",

--- a/src/data-source/options/utils/env.ts
+++ b/src/data-source/options/utils/env.ts
@@ -1,6 +1,6 @@
 import type { DataSourceOptions } from 'typeorm';
 import type { BaseDataSourceOptions } from 'typeorm/data-source/BaseDataSourceOptions';
-import type { PostgresConnectionOptions } from 'typeorm/driver/postgres/PostgresConnectionOptions';
+import type { PostgresDataSourceOptions } from 'typeorm/driver/postgres/PostgresDataSourceOptions';
 import type { DatabaseType } from 'typeorm/driver/types/DatabaseType';
 import type { LoggerOptions } from 'typeorm/logger/LoggerOptions';
 import { useEnv } from '../../../env';
@@ -59,7 +59,7 @@ export function readDataSourceOptionsFromEnv() : DataSourceOptions | undefined {
             ...credentialOptions,
             type: base.type,
             schema: useEnv('schema'),
-            uuidExtension: useEnv('uuidExtension') as PostgresConnectionOptions['uuidExtension'],
+            uuidExtension: useEnv('uuidExtension') as PostgresDataSourceOptions['uuidExtension'],
         };
     }
 
@@ -70,14 +70,6 @@ export function readDataSourceOptionsFromEnv() : DataSourceOptions | undefined {
             type: base.type,
             schema: useEnv('schema'),
             timeTravelQueries: true,
-        };
-    }
-
-    if (base.type === 'sqlite') {
-        return {
-            ...base,
-            type: base.type,
-            database: useEnv('database') || 'db.sqlite',
         };
     }
 

--- a/src/database/driver/utils/create.ts
+++ b/src/database/driver/utils/create.ts
@@ -2,7 +2,6 @@ import type { DataSource, DataSourceOptions } from 'typeorm';
 import { DriverFactory } from 'typeorm/driver/DriverFactory';
 
 const driversRequireDatabaseOption: DataSourceOptions['type'][] = [
-    'sqlite',
     'better-sqlite3',
 ];
 

--- a/src/database/methods/create/module.ts
+++ b/src/database/methods/create/module.ts
@@ -40,7 +40,6 @@ export async function createDatabase(input: DatabaseCreateContextInput = {}) : P
         case 'cockroachdb':
             output = await createCockroachDBDatabase(context);
             break;
-        case 'sqlite':
         case 'better-sqlite3':
             output = await createSQLiteDatabase(context);
             break;

--- a/src/database/methods/drop/module.ts
+++ b/src/database/methods/drop/module.ts
@@ -40,7 +40,6 @@ export async function dropDatabase(input: DatabaseDropContextInput = {}) : Promi
         case 'cockroachdb':
             output = await dropCockroachDBDatabase(context);
             break;
-        case 'sqlite':
         case 'better-sqlite3':
             output = await dropSQLiteDatabase(context);
             break;

--- a/test/unit/data-source/options/merge.spec.ts
+++ b/test/unit/data-source/options/merge.spec.ts
@@ -1,4 +1,4 @@
-import type { PostgresConnectionOptions } from 'typeorm/driver/postgres/PostgresConnectionOptions';
+import type { PostgresDataSourceOptions } from 'typeorm/driver/postgres/PostgresDataSourceOptions';
 import { mergeDataSourceOptions } from '../../../../src';
 
 describe('src/data-source/options/merge', () => {
@@ -13,7 +13,7 @@ describe('src/data-source/options/merge', () => {
 
         expect(options).toBeDefined();
         expect(options.type).toEqual('postgres');
-        expect((options as PostgresConnectionOptions).password).toEqual('password');
+        expect((options as PostgresDataSourceOptions).password).toEqual('password');
     });
 
     it('should not merge data source options', () => {
@@ -27,6 +27,6 @@ describe('src/data-source/options/merge', () => {
 
         expect(options).toBeDefined();
         expect(options.type).toEqual('postgres');
-        expect((options as PostgresConnectionOptions).password).toBeUndefined();
+        expect((options as PostgresDataSourceOptions).password).toBeUndefined();
     });
 });


### PR DESCRIPTION
## Summary

- Bump `peerDependencies.typeorm` (and devDep) from `~0.3.0` to `^1.0.0`. TypeORM `0.3.x` is no longer supported on `typeorm-extension` v4+ — stay on v3 if you need it.
- Drop the `sqlite` driver from `createDatabase` / `dropDatabase` / `TYPEORM_CONNECTION` env handling; TypeORM 1.0 [removed it upstream](https://typeorm.io/docs/releases/1.0/release-notes/), only `better-sqlite3` remains.
- Rename the one deep-import that TypeORM 1.0 renamed: `typeorm/driver/postgres/PostgresConnectionOptions` → `typeorm/driver/postgres/PostgresDataSourceOptions`.
- Refresh `docs/guide/migration-guide-v4.md`, `AGENTS.md`, `.agents/structure.md`, `.agents/architecture.md`.

Every other deep-import path and public API we use (`DataSource`, `DataSourceOptions`, `MigrationExecutor`, `MigrationGenerateCommand`, `Brackets`, `Repository`, `EntityMetadata`, `InstanceChecker`, `DriverFactory`, `DriverUtils`, `MongoQueryRunner`, `MssqlParameter`, `Table`, `Migration`, all `typeorm/driver/<x>/<X>Driver` imports) still resolves under TypeORM 1.0 — sqlite was the only build-time break.

Closes #1371

## Test plan

- [x] `npm run build` (types + tsdown) green
- [x] `npm test` — 21 files / 51 tests pass against `typeorm@1.0.0`
- [x] `npm run lint` clean
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TypeORM peer dependency to `1.0.0` (version 0.3.x no longer supported for v4+)

* **Documentation**
  * Expanded v4 migration guide with TypeORM 1.0 breaking changes and upgrade paths
  * Clarified better-sqlite3 as the required SQLite driver (legacy sqlite removed)
  * Updated architecture and compatibility documentation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tada5hi/typeorm-extension/pull/1377?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->