### PR TITLE
fix(metadata): add homepage and bugs fields to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
         "type": "git",
         "url": "https://github.com/tada5hi/typeorm-extension.git"
     },
+    "homepage": "https://typeorm-extension.tada5hi.net",
+    "bugs": {
+        "url": "https://github.com/tada5hi/typeorm-extension/issues"
+    },
     "main": "dist/index.mjs",
     "types": "dist/index.d.mts",
     "exports": {


### PR DESCRIPTION
## Summary

Add the standard npm `homepage` and `bugs` fields to `package.json`.

## Problem

The published `typeorm-extension@3.9.0` and the current master manifest (`4.0.0-beta.0`) expose `repository` and `license` metadata but omit `homepage` and `bugs`. Registry clients and package tooling therefore cannot resolve documentation or issue-tracker links directly from the package manifest.

Reproduce:
```sh
npm view typeorm-extension@3.9.0 name version repository homepage bugs license --json
```

Actual: `repository` and `license` present; `homepage` and `bugs` absent.

## Fix

Add the two fields beside the existing `repository` entry:

```json
"homepage": "https://typeorm-extension.tada5hi.net",
"bugs": {
  "url": "https://github.com/tada5hi/typeorm-extension/issues"
}
```

- The documentation URL `https://typeorm-extension.tada5hi.net` is already published via VitePress and is documented in `AGENTS.md`.
- The `bugs.url` points at the canonical issue tracker on this repository.

## Scope

Metadata-only. No runtime code, dependencies, exports, build output, or tests are changed. `name`, `version`, and `repository` are byte-identical to upstream master.

## Validation

```sh
python3 -m json.tool package.json   # parses cleanly
git diff --check                     # clean
```

Diff stat: 1 file changed, 4 insertions(+).

Refs tada5hi/typeorm-extension#1395

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added project homepage link
  * Added bug reporting contact information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->