### PR TITLE
chore: add npm homepage and bugs metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
         "type": "git",
         "url": "https://github.com/tada5hi/typeorm-extension.git"
     },
+    "homepage": "https://typeorm-extension.tada5hi.net",
+    "bugs": {
+        "url": "https://github.com/tada5hi/typeorm-extension/issues"
+    },
     "main": "dist/index.mjs",
     "types": "dist/index.d.mts",
     "exports": {


### PR DESCRIPTION
## Summary

- add the official documentation URL as npm `homepage` metadata
- add `bugs.url` so registry clients can link directly to the issue tracker
- keep the patch metadata-only with no runtime, dependency, export, or build changes

Closes #1395

## Validation

- `npm run build` passed (TypeScript and tsdown library/CLI builds)
- `npm run lint` passed
- Vitest: 35 of 51 tests passed locally; the remaining failures depend on the missing `better-sqlite3` native binding after the upstream lockfile mismatch required an `--ignore-scripts` install, plus one existing Windows path-separator assertion
- `pnpm pack --dry-run --json`
- direct Node assertions for both metadata values
- `git diff --check`

## Environment note

`npm ci` currently rejects the upstream branch because `package.json` requires esbuild 0.28.1 while `package-lock.json` does not contain it. I installed the current manifest without writing the lockfile and without lifecycle scripts, which is why SQLite-backed tests could not load their native binary. The repository CI should provide the authoritative clean Linux test result.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project metadata to include homepage and bug tracking information for improved discoverability and issue reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->