### PR TITLE
feat!: apply SQL database semantics to the sqlite dialect

### DIFF
--- a/src/database/adapters/node-fs.ts
+++ b/src/database/adapters/node-fs.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import type { IFileSystem } from '../core';
+import { hasErrorCode } from './utils';
 
 export class NodeFileSystem implements IFileSystem {
     async assertDirectoryWritable(path: string): Promise<void> {
@@ -11,7 +12,7 @@ export class NodeFileSystem implements IFileSystem {
             await fs.promises.access(path, fs.constants.F_OK | fs.constants.W_OK);
             return true;
         } catch (error) {
-            if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+            if (hasErrorCode(error, 'ENOENT')) {
                 return false;
             }
 
@@ -28,7 +29,7 @@ export class NodeFileSystem implements IFileSystem {
             await fs.promises.unlink(path);
             return true;
         } catch (error) {
-            if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+            if (hasErrorCode(error, 'ENOENT')) {
                 return false;
             }
 

--- a/src/database/adapters/node-fs.ts
+++ b/src/database/adapters/node-fs.ts
@@ -10,12 +10,29 @@ export class NodeFileSystem implements IFileSystem {
         try {
             await fs.promises.access(path, fs.constants.F_OK | fs.constants.W_OK);
             return true;
-        } catch {
-            return false;
+        } catch (error) {
+            if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+                return false;
+            }
+
+            throw error;
         }
     }
 
-    async removeFile(path: string): Promise<void> {
-        await fs.promises.unlink(path);
+    async createFile(path: string): Promise<void> {
+        await fs.promises.writeFile(path, '', { flag: 'wx' });
+    }
+
+    async removeFile(path: string): Promise<boolean> {
+        try {
+            await fs.promises.unlink(path);
+            return true;
+        } catch (error) {
+            if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+                return false;
+            }
+
+            throw error;
+        }
     }
 }

--- a/src/database/adapters/utils.ts
+++ b/src/database/adapters/utils.ts
@@ -1,3 +1,15 @@
+import { isObject } from 'locter';
+import { hasOwnProperty } from '../../utils';
+
+/**
+ * Whether the (unknown) error carries the given errno code.
+ */
+export function hasErrorCode(error: unknown, code: string): boolean {
+    return isObject(error) &&
+        hasOwnProperty(error, 'code') &&
+        error.code === code;
+}
+
 /**
  * Normalize a callback style client (pg, mysql2) query to a promise.
  */

--- a/src/database/core/mssql/statements.ts
+++ b/src/database/core/mssql/statements.ts
@@ -2,17 +2,15 @@ import type { ConnectionParams } from '../type';
 
 /**
  * @link https://github.com/typeorm/typeorm/blob/master/src/driver/sqlserver/SqlServerQueryRunner.ts#L416
+ *
+ * NOTE: the previous implementation appended a `CHARACTER SET` clause,
+ * which is not valid T-SQL (SQL Server uses `COLLATE <collation_name>`).
+ * The clause was removed; a proper collation option is future work.
  */
 export function buildMsSQLCreateDatabaseQuery(params: ConnectionParams, ifNotExist: boolean): string {
-    let query = ifNotExist ?
+    return ifNotExist ?
         `IF DB_ID('${params.database}') IS NULL CREATE DATABASE "${params.database}"` :
         `CREATE DATABASE "${params.database}"`;
-
-    if (typeof params.characterSet === 'string') {
-        query += ` CHARACTER SET ${params.characterSet}`;
-    }
-
-    return query;
 }
 
 /**

--- a/src/database/core/sqlite/module.ts
+++ b/src/database/core/sqlite/module.ts
@@ -1,4 +1,4 @@
-import { OptionsError } from '../../../errors';
+import { DriverError, OptionsError } from '../../../errors';
 import type {
     DatabaseCreateOperation,
     DatabaseDropOperation,
@@ -9,7 +9,9 @@ import { resolveSQLiteDatabaseDirectory, resolveSQLiteDatabasePath } from './pat
 
 /**
  * better-sqlite3 never opens a server connection —
- * create/drop are filesystem effects.
+ * create/drop are filesystem effects following SQL database semantics:
+ * create produces the file (or fails when it exists, unless ifNotExist),
+ * drop removes it (or fails when it is missing, unless ifExist).
  */
 export class SQLiteDialect implements IDatabaseDialect {
     constructor(
@@ -25,9 +27,16 @@ export class SQLiteDialect implements IDatabaseDialect {
             throw OptionsError.databaseNotDefined();
         }
 
+        const filePath = resolveSQLiteDatabasePath(operation.params.database, this.cwd);
         const directoryPath = resolveSQLiteDatabaseDirectory(operation.params.database, this.cwd);
 
         await this.fs.assertDirectoryWritable(directoryPath);
+
+        if (operation.ifNotExist && await this.fs.isFileWritable(filePath)) {
+            return undefined;
+        }
+
+        await this.fs.createFile(filePath);
 
         return undefined;
     }
@@ -39,8 +48,10 @@ export class SQLiteDialect implements IDatabaseDialect {
 
         const filePath = resolveSQLiteDatabasePath(operation.params.database, this.cwd);
 
-        if (operation.ifExist && await this.fs.isFileWritable(filePath)) {
-            await this.fs.removeFile(filePath);
+        const removed = await this.fs.removeFile(filePath);
+
+        if (!removed && !operation.ifExist) {
+            throw DriverError.databaseNotFound(operation.params.database);
         }
 
         return undefined;

--- a/src/database/core/type.ts
+++ b/src/database/core/type.ts
@@ -38,9 +38,22 @@ export interface IDatabaseConnectionFactory {
 export interface IFileSystem {
     assertDirectoryWritable(path: string): Promise<void>;
 
+    /**
+     * Whether the file exists and is writable.
+     * A missing file yields false; any other failure propagates.
+     */
     isFileWritable(path: string): Promise<boolean>;
 
-    removeFile(path: string): Promise<void>;
+    /**
+     * Create an empty file. Fails when the file already exists.
+     */
+    createFile(path: string): Promise<void>;
+
+    /**
+     * Remove the file. Returns false when it did not exist;
+     * any other failure propagates.
+     */
+    removeFile(path: string): Promise<boolean>;
 }
 
 /**

--- a/src/errors/driver.ts
+++ b/src/errors/driver.ts
@@ -16,4 +16,8 @@ export class DriverError extends TypeormExtensionError {
     static connectionClosed() {
         return new DriverError('The database connection has already been closed.');
     }
+
+    static databaseNotFound(database: string) {
+        return new DriverError(`The database ${database} does not exist.`);
+    }
 }

--- a/test/data/database/memory-file-system.ts
+++ b/test/data/database/memory-file-system.ts
@@ -17,8 +17,22 @@ export class MemoryFileSystem implements IFileSystem {
         return this.files.has(path);
     }
 
-    async removeFile(path: string): Promise<void> {
+    async createFile(path: string): Promise<void> {
+        if (this.files.has(path)) {
+            throw new Error(`The file ${path} already exists.`);
+        }
+
+        this.files.add(path);
+    }
+
+    async removeFile(path: string): Promise<boolean> {
+        if (!this.files.has(path)) {
+            return false;
+        }
+
         this.files.delete(path);
         this.removed.push(path);
+
+        return true;
     }
 }

--- a/test/unit/data-source/singleton.spec.ts
+++ b/test/unit/data-source/singleton.spec.ts
@@ -7,6 +7,12 @@ import {
 } from '../../../src';
 
 describe('src/data-source/singleton.ts', () => {
+    afterAll(async () => {
+        if (dataSource.isInitialized) {
+            await dataSource.destroy();
+        }
+    });
+
     it('should set and use datasource', async () => {
         setDataSource(dataSource);
 

--- a/test/unit/database/core/mssql.spec.ts
+++ b/test/unit/database/core/mssql.spec.ts
@@ -17,7 +17,7 @@ describe('src/database/core/mssql', () => {
         expect(connectionFactory.openConnections.size).toEqual(0);
     });
 
-    it('should create database with character set', async () => {
+    it('should not append a character set clause', async () => {
         const connectionFactory = new MemoryDatabaseConnectionFactory();
         const dialect = new MsSQLDialect(connectionFactory);
 
@@ -27,7 +27,7 @@ describe('src/database/core/mssql', () => {
         });
 
         expect(connectionFactory.statements()).toEqual([
-            'CREATE DATABASE "app" CHARACTER SET UTF8',
+            'CREATE DATABASE "app"',
         ]);
     });
 

--- a/test/unit/database/core/registry.spec.ts
+++ b/test/unit/database/core/registry.spec.ts
@@ -50,7 +50,7 @@ describe('src/database/registry', () => {
         expect(resolveDatabaseDialectName('mariadb')).toEqual('mysql');
     });
 
-    it('should run the sqlite dialect with default rejecting connectors', async () => {
+    it('should run the sqlite dialect through the composition root', async () => {
         const fs = new MemoryFileSystem();
         fs.writableDirectories.add('/data');
 
@@ -60,7 +60,7 @@ describe('src/database/registry', () => {
             synchronize: false,
         }, { fs, cwd: '/data' });
 
-        fs.files.add('/data/app');
+        expect(fs.files.has('/data/app')).toBeTruthy();
 
         await executeDatabaseDrop('better-sqlite3', {
             options: optionsFor('better-sqlite3'),

--- a/test/unit/database/core/sqlite.spec.ts
+++ b/test/unit/database/core/sqlite.spec.ts
@@ -1,22 +1,58 @@
 import path from 'node:path';
-import { OptionsError } from '../../../../src/errors';
+import { DriverError, OptionsError } from '../../../../src/errors';
 import {
     SQLiteDialect,
     resolveSQLiteDatabasePath,
 } from '../../../../src/database/core';
 import { MemoryFileSystem } from '../../../data/database';
 
+const database = path.join('writable', 'db.sqlite');
+const filePath = path.join('/cwd', 'writable', 'db.sqlite');
+
+const createFileSystem = () => {
+    const fs = new MemoryFileSystem();
+    fs.writableDirectories.add(path.join('/cwd', 'writable'));
+
+    return fs;
+};
+
 describe('src/database/core/sqlite', () => {
-    it('should verify the database directory on create', async () => {
-        const fs = new MemoryFileSystem();
-        fs.writableDirectories.add(path.join('/cwd', 'writable'));
+    it('should create the database file', async () => {
+        const fs = createFileSystem();
+        const dialect = new SQLiteDialect(fs, '/cwd');
+
+        await dialect.create({
+            params: { database },
+            ifNotExist: false,
+        });
+
+        expect(fs.files.has(filePath)).toBeTruthy();
+    });
+
+    it('should keep an existing database file with the exist guard', async () => {
+        const fs = createFileSystem();
+        fs.files.add(filePath);
 
         const dialect = new SQLiteDialect(fs, '/cwd');
 
         await dialect.create({
-            params: { database: path.join('writable', 'db.sqlite') },
+            params: { database },
             ifNotExist: true,
         });
+
+        expect(fs.files.has(filePath)).toBeTruthy();
+    });
+
+    it('should fail on create when the database file already exists', async () => {
+        const fs = createFileSystem();
+        fs.files.add(filePath);
+
+        const dialect = new SQLiteDialect(fs, '/cwd');
+
+        await expect(dialect.create({
+            params: { database },
+            ifNotExist: false,
+        })).rejects.toThrow('already exists');
     });
 
     it('should fail on create when the directory is not writable', async () => {
@@ -24,7 +60,7 @@ describe('src/database/core/sqlite', () => {
         const dialect = new SQLiteDialect(fs, '/cwd');
 
         await expect(dialect.create({
-            params: { database: path.join('writable', 'db.sqlite') },
+            params: { database },
             ifNotExist: true,
         })).rejects.toThrow('not writable');
     });
@@ -43,41 +79,40 @@ describe('src/database/core/sqlite', () => {
         })).rejects.toThrow(OptionsError);
     });
 
-    it('should remove the database file on drop', async () => {
-        const filePath = path.join('/cwd', 'writable', 'db.sqlite');
-
-        const fs = new MemoryFileSystem();
+    it('should remove the database file on drop, even without the exist guard', async () => {
+        const fs = createFileSystem();
         fs.files.add(filePath);
 
         const dialect = new SQLiteDialect(fs, '/cwd');
 
         await dialect.drop({
-            params: { database: path.join('writable', 'db.sqlite') },
-            ifExist: true,
+            params: { database },
+            ifExist: false,
         });
 
         expect(fs.removed).toEqual([filePath]);
     });
 
-    it('should not remove anything when the file is missing or ifExist is unset', async () => {
-        const filePath = path.join('/cwd', 'writable', 'db.sqlite');
-
-        const fs = new MemoryFileSystem();
+    it('should ignore a missing database file with the exist guard', async () => {
+        const fs = createFileSystem();
         const dialect = new SQLiteDialect(fs, '/cwd');
 
         await dialect.drop({
-            params: { database: path.join('writable', 'db.sqlite') },
+            params: { database },
             ifExist: true,
         });
 
-        fs.files.add(filePath);
-
-        await dialect.drop({
-            params: { database: path.join('writable', 'db.sqlite') },
-            ifExist: false,
-        });
-
         expect(fs.removed).toEqual([]);
+    });
+
+    it('should fail on drop when the database file is missing', async () => {
+        const fs = createFileSystem();
+        const dialect = new SQLiteDialect(fs, '/cwd');
+
+        await expect(dialect.drop({
+            params: { database },
+            ifExist: false,
+        })).rejects.toThrow(DriverError);
     });
 
     it('should resolve relative and absolute database paths', () => {


### PR DESCRIPTION
Phase 0 of the architecture roadmap: the dialect-semantics decisions deferred from #1401, plus one test quick win.

## Decisions (from #1402)

1. **better-sqlite3 create produces the database file.** Exclusive create (`wx`): an existing file fails the operation unless `ifNotExist` — matching `CREATE DATABASE` semantics. Previously create only verified the directory was writable and reported success without a file.
2. **better-sqlite3 drop follows `DROP DATABASE ... IF EXISTS` semantics.** The file is always removed; a missing file fails with the new `DriverError.databaseNotFound()` unless `ifExist`. Previously `ifExist: false` was a silent no-op.
3. **Filesystem errors are no longer swallowed.** The `IFileSystem` contract now treats only `ENOENT` as absence — `EACCES`/`EIO`/invalid-path failures propagate instead of silently leaving database files behind. The contract gains `createFile()` and `removeFile()` reports whether the file existed.
4. **mssql: the invalid `CREATE DATABASE ... CHARACTER SET` clause is removed.** It is not valid T-SQL, so the statement could never have executed successfully — nothing working depended on it. Proper `COLLATE` support is future work.
5. **oracle stays as-is** (documented dubious `CREATE DATABASE IF NOT EXISTS`, drop as no-op) — revisit only when someone with an Oracle setup needs it, per the issue discussion.

## Quick win

`test/unit/data-source/singleton.ts` → `singleton.spec.ts`: the file never matched vitest's include pattern, so the data-source alias/caching logic had a test file that never ran. Now it does (plus proper DataSource teardown).

## Validation

115 tests (5 net new), branch coverage 81.33% (gate: 80%), build + lint green.

BREAKING CHANGE: For better-sqlite3, `createDatabase` creates the database file itself (previously it only verified the directory was writable), and `dropDatabase` without `ifExist` fails on a missing file (previously a silent no-op).

Closes #1402

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved filesystem-backed database file creation/deletion: exclusive file creation, and clearer outcomes when paths are missing or already exist.
  - SQLite create/drop logic now consistently validates writable directories and throws when a missing database must be removed.
  - SQL Server `CREATE DATABASE` no longer emits unsupported character set clauses.
  - Added a dedicated “database not found” error for missing database scenarios.
- **New Features**
  - Added an error-code helper to detect specific failure codes.
- **Tests**
  - Updated and expanded unit tests to match the new filesystem behaviors, SQL generation, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->