### PR TITLE
fix!: remove the seeder executor's global data-source registration side effect

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -24,7 +24,7 @@
        │adapters/   │   │  (faker)     │              │  env merge   │   │  rapiq parse │
        └────────────┘   └──────────────┘              └──────────────┘   └──────────────┘
 
-  Shared infra: src/env (envix), src/errors, src/utils (file-path/tsconfig/object), src/helpers
+  Shared infra: src/runtime (state registry), src/env (envix), src/errors, src/utils (file-path/tsconfig/object), src/helpers
 ```
 
 The CLI is a *thin* layer — every command just calls a function from the public API.
@@ -50,7 +50,7 @@ The peer-dep range is `typeorm ^1.0.0`. TypeORM 0.3 is **not** supported on `typ
 
 ### 3. DataSource registry with alias-keyed lazy init
 
-`src/data-source/singleton.ts` keeps a `Record<alias, DataSource>` plus parallel promise caches so `useDataSource(alias)` is idempotent and concurrent-safe. The default alias is `'default'`. `setDataSource()` registers a pre-built instance; `useDataSource()` builds + initializes one from discovered options if none is registered. This is why the library can be used in apps that never call `findDataSource` themselves.
+`src/data-source/singleton.ts` stores data sources in the runtime registry's alias-keyed `AsyncKeyedCache`, so `useDataSource(alias)` is idempotent and concurrent-safe (concurrent calls share one build; a failed build is evicted for retry). The default alias is `'default'`. `setDataSource()` registers a pre-built instance; `useDataSource()` builds + initializes one from discovered options if none is registered. This is why the library can be used in apps that never call `findDataSource` themselves.
 
 ### 4. Query application delegates parsing to `rapiq`
 
@@ -81,15 +81,19 @@ export async function createDatabase(input: DatabaseCreateContextInput = {}) {
 }
 ```
 
-### Singleton registry pattern (data sources, factories, env)
+### Runtime registry pattern (data sources, options, env, factories)
 
-State that must survive across calls in the same process is stored in module-local `Record`s, with `set*` / `has*` / `use*` / `unset*` (and sometimes `reset*`) functions:
+All state that must survive across calls in the same process lives in one place: the `RuntimeRegistry` (`src/runtime/module.ts`, reachable via `useRuntimeRegistry()`). It owns four slots:
 
-- `src/data-source/singleton.ts` → `instances`, `initializePromises`, `optionsPromises`
-- `src/env/module.ts` → single `instance` cache, with `resetEnv()`
-- `src/seeder/factory/manager.ts` → `SeederFactoryManager.items` keyed by entity name
+- `dataSources` / `dataSourceOptions` — two alias-keyed `AsyncKeyedCache` instances (`src/runtime/cache.ts`): get-or-build with concurrent-call dedupe and failed-build eviction.
+- `env` — the memoized `Environment` read by `useEnv()`.
+- `factories` — the `SeederFactoryManager` instance (`items` keyed by entity name).
 
-`useEnv()` is cached on first read; tests that mutate `process.env` must call `resetEnv()` between cases.
+The registry is **internal** (not in the public barrel). Consumers interact through the per-domain accessors, which are thin delegates: `setDataSource` / `hasDataSource` / `useDataSource` / `unsetDataSource`, `setDataSourceOptions` / `hasDataSourceOptions` / `useDataSourceOptions`, `useEnv` / `resetEnv`, `useSeederFactoryManager` / `setSeederFactory` / `resetSeederFactoryManager`. `RuntimeRegistry.reset()` restores a pristine process state (used by tests).
+
+`useEnv()` is cached on first read; tests that mutate `process.env` must call `resetEnv()` between cases. Don't add new process-global state outside the registry.
+
+Note: `SeederExecutor` does **not** register its data source globally (a v3 side effect removed in v4). Each run gets a `SeederFactoryManager` bound to the executor's data source (sharing the globally registered factory items), so factory `save()` persists into the executor's database; unbound factories fall back to `useDataSource()`.
 
 ### defineCommand pattern (CLI)
 
@@ -135,7 +139,7 @@ Each command body runs inside `runWithExitCode(logger, async () => { … })` (`s
 
 ### Factory pattern (seeder/factory)
 
-`setSeederFactory(Entity, callback)` registers a faker-driven generator with the global `SeederFactoryManager`. A `Seeder.run(dataSource, factoryManager)` impl calls `factoryManager.get(Entity).createMany(n)`. The factory `callback` receives a `Faker` instance from `@faker-js/faker` (peer dep — only loaded when factories are actually used).
+`setSeederFactory(Entity, callback)` registers a faker-driven generator with the global `SeederFactoryManager`. A `Seeder.run(dataSource, factoryManager)` impl calls `factoryManager.get(Entity).createMany(n)`. The factory `callback` receives a `Faker` instance from `@faker-js/faker` (peer dep — only loaded when factories are actually used). The manager handed to `run()` is bound to the executor's data source (sharing the global `items`), so `save()` / `saveMany()` persist there; factories resolved outside a run fall back to `useDataSource()`.
 
 ## Data Flow
 
@@ -165,11 +169,12 @@ Input:
 
 Processing:
   1. SeederExecutor.buildOptions() merges options ← dataSource.options ← env ← defaults
-  2. (optional) prepareSeederFactories() loads factory files via glob → registers in manager
+  2. (optional) prepareSeederFactories() loads factory files via glob → registers in the global manager
   3. prepareSeederSeeds() loads seed files via glob → constructs entities
   4. If tracking: create `seeds` table if missing, load already-executed names
   5. Filter to pending = (matches seedName?) AND (not already tracked OR not tracking)
-  6. For each pending: instantiate, call .run(dataSource, factoryManager), optionally insert tracking row
+  6. For each pending: instantiate, call .run(dataSource, factoryManager) with a manager bound to
+     the executor's data source, optionally insert tracking row
 
 Output:
   └── SeederEntity[] of seeds actually executed
@@ -214,7 +219,8 @@ Native client adapters   → src/database/adapters/<driver>.ts
 Deprecated delegates     → src/database/driver/<driver>.ts (removed next major)
 Context builders         → src/database/utils/context.ts
 Schema sync after create → src/database/utils/schema.ts
-DataSource registry      → src/data-source/singleton.ts
+Runtime state registry   → src/runtime/module.ts (+ cache.ts — AsyncKeyedCache)
+DataSource registry      → src/data-source/singleton.ts (delegates to src/runtime)
 DataSource discovery     → src/data-source/find/module.ts
 DataSource options merge → src/data-source/options/module.ts + utils/{env,merge}.ts
 Seeder runtime           → src/seeder/executor.ts, src/seeder/module.ts

--- a/.agents/structure.md
+++ b/.agents/structure.md
@@ -35,6 +35,9 @@ typeorm-extension/
 │   │   ├── module.ts           # applyQuery() / applyQueryParseOutput() — public entry
 │   │   ├── parameter/          # fields, filters, pagination, relations, sort
 │   │   └── utils/              # alias/key/option helpers
+│   ├── runtime/                # Process-global state registry (internal, not in the public barrel)
+│   │   ├── cache.ts            # AsyncKeyedCache — keyed get-or-build with concurrent dedupe
+│   │   └── module.ts           # RuntimeRegistry + useRuntimeRegistry() — owns data sources, options, env, factories
 │   ├── seeder/                 # Seeder + factory runtime
 │   │   ├── executor.ts         # SeederExecutor — orchestrates run + tracking table
 │   │   ├── module.ts           # runSeeder / runSeeders
@@ -71,6 +74,7 @@ typeorm-extension/
 | `errors/`        | Error class hierarchy (`TypeormExtensionError` → `DriverError` / `OptionsError`).                      |
 | `helpers/`       | Entity-shape helpers (`getEntityName`) — used across seeder and query modules.                         |
 | `query/`         | Apply parsed JSON:API query input onto a `SelectQueryBuilder`. Delegates parsing to `rapiq`.           |
+| `runtime/`       | Internal registry for process-global state (data sources, options, env, factory manager) with a uniform `reset()`. |
 | `seeder/`        | Discover and execute seeders, manage factories, track executed seeds in a `seeds` table.               |
 | `utils/`         | Generic, framework-free helpers (tsconfig reading, file-path adjustment, object/promise/slash utils).  |
 
@@ -126,4 +130,4 @@ CLI command factories are **not** part of the public barrel — they are interna
 - **Public, programmatic API** → everything else under `src/`, re-exported from `src/index.ts`.
 - **Driver-specific SQL** → `src/database/core/<dialect>/statements.ts` (pure builders), orchestrated by `src/database/core/<dialect>/module.ts` over the connections; native clients live only in `src/database/adapters/`. Adding a new TypeORM driver means one dialect folder in `core/`, one adapter, and one row in `src/database/registry.ts`.
 - **Query application** → `src/query/parameter/<concern>/` — one folder per JSON:API concern (`fields`, `filters`, `pagination`, `relations`, `sort`).
-- **Side-effectful state** (DataSource registry, env cache, factory manager) → singletons in `src/data-source/singleton.ts`, `src/env/module.ts`, `src/seeder/factory/manager.ts`.
+- **Side-effectful state** (DataSource registry, options cache, env cache, factory manager) → one `RuntimeRegistry` in `src/runtime/module.ts`; the public accessors (`setDataSource`/`useDataSource`, `useEnv`/`resetEnv`, `useSeederFactoryManager`/`resetSeederFactoryManager`, …) are thin delegates in their own domains.

--- a/.agents/testing.md
+++ b/.agents/testing.md
@@ -34,6 +34,7 @@ The handful of cases that *do* avoid the real ORM (pure query-builder transforms
 | `test/unit/env/`         | `useEnv()` env-var reading + `resetEnv()` cache invalidation         |
 | `test/unit/helper/`      | Entity inspection helpers (join columns, property names, uniqueness) |
 | `test/unit/query/`       | `applyQuery` end-to-end and per-parameter (fields/filters/…)         |
+| `test/unit/runtime/`     | `AsyncKeyedCache` semantics, `RuntimeRegistry` state + `reset()`     |
 | `test/unit/seeder/`      | Seeder execution, tracking, factory manager                          |
 | `test/unit/utils/`       | Pure helper functions                                                |
 
@@ -88,7 +89,7 @@ expect(qb.calls).toEqual([...]);
 const qb = { where: jest.fn(), leftJoin: jest.fn() } as any;
 ```
 
-After mutating `process.env` in a test, call `resetEnv()` from `src/env` to clear the cached `Environment` instance, otherwise the next test sees stale values.
+After mutating `process.env` in a test, call `resetEnv()` from `src/env` to clear the cached `Environment` instance, otherwise the next test sees stale values. For a full process-state teardown (data sources, options, env, factories at once), call `useRuntimeRegistry().reset()` from `src/runtime` (internal module — import it by path in tests).
 
 Test files that need a directory reference must use `import.meta.dirname` (Node 22+) — `__dirname` is not available because the package is ESM-only.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,7 @@ npm run docs:build         # production build
 
 ## Detailed Guides
 
-- **[Project Structure](.agents/structure.md)** — Source layout, the top-level domains (`cli`, `data-source`, `database`, `env`, `errors`, `helpers`, `query`, `seeder`, `utils`), and what each owns.
+- **[Project Structure](.agents/structure.md)** — Source layout, the top-level domains (`cli`, `data-source`, `database`, `env`, `errors`, `helpers`, `query`, `runtime`, `seeder`, `utils`), and what each owns.
 - **[Architecture](.agents/architecture.md)** — Dialect core + connection-port adapters for `create/drop` (pure SQL dialects, native clients behind ports, one registry dispatch), context-builder pipeline, data-source singleton/alias registry, query-parameter pipeline on top of `rapiq`, and seeder execution model.
 - **[Testing](.agents/testing.md)** — Vitest + `unplugin-swc` (for decorator metadata), SQLite-backed integration tests in `test/unit/`, fixture entities/factories/seeds in `test/data/`, and the 80% coverage gate.
 - **[Conventions](.agents/conventions.md)** — `@tada5hi/eslint-config` v2 (ESLint v10 flat config), Conventional Commits via commitlint + husky, barrel `index.ts` per module, and the release-please + monoship release flow.

--- a/README.MD
+++ b/README.MD
@@ -467,6 +467,10 @@ export default class UserSeeder implements Seeder {
 }
 ```
 
+Factories obtained through the `factoryManager` argument are bound to the data source of the
+current seeder run — `save()` and `saveMany()` persist there. A factory used outside a seeder
+run falls back to the data source registered for the `default` alias.
+
 #### Execute
 
 Populate the database from the code base:

--- a/docs/guide/migration-guide-v4.md
+++ b/docs/guide/migration-guide-v4.md
@@ -58,6 +58,24 @@ The TypeORM 1.0 upstream changes that affect `typeorm-extension` consumers:
 
 See the [TypeORM 1.0 release notes](https://typeorm.io/docs/releases/1.0/release-notes/) for the full list of upstream breaking changes.
 
+### Seeder execution no longer registers the data source globally
+
+In v3, constructing a `SeederExecutor` (which `runSeeder` / `runSeeders` do internally) registered the
+given data source under the `default` alias as a side effect — silently repointing what
+`useDataSource()` returns everywhere else in the process.
+
+In v4, the executor leaves the data-source registry untouched. Factories resolved through the
+`factoryManager` passed to `Seeder.run()` are bound to the executor's data source, so factory
+`save()` / `saveMany()` still persist into the seeded database. If other code relies on
+`useDataSource()` returning the seeded data source, register it explicitly:
+
+```typescript
+import { runSeeders, setDataSource } from 'typeorm-extension';
+
+setDataSource(dataSource); // was implicit in v3
+await runSeeders(dataSource);
+```
+
 ## Internal Toolchain (no consumer impact)
 
 For contributors only:

--- a/docs/guide/seeding-api-reference.md
+++ b/docs/guide/seeding-api-reference.md
@@ -172,3 +172,19 @@ export type SeederOptions = {
     factoriesLoad?: boolean
 };
 ```
+
+## `resetSeederFactoryManager`
+
+```typescript
+declare function resetSeederFactoryManager() : void;
+```
+
+Drop all factories registered via `setSeederFactory`, so the next access starts from a clean
+manager. Useful in tests and long-lived processes where factory registrations would otherwise
+accumulate for the lifetime of the process.
+
+```typescript
+import { resetSeederFactoryManager } from 'typeorm-extension';
+
+resetSeederFactoryManager();
+```

--- a/docs/guide/seeding-api-reference.md
+++ b/docs/guide/seeding-api-reference.md
@@ -179,9 +179,11 @@ export type SeederOptions = {
 declare function resetSeederFactoryManager() : void;
 ```
 
-Drop all factories registered via `setSeederFactory`, so the next access starts from a clean
-manager. Useful in tests and long-lived processes where factory registrations would otherwise
-accumulate for the lifetime of the process.
+Reset the global factory manager: the managed instance is discarded, so the next access
+(`setSeederFactory`, `useSeederFactory`, a seeder run) starts with a fresh, empty manager.
+Factory instances created before the reset keep working. Useful in tests and long-lived
+processes where the manager's registrations would otherwise accumulate for the lifetime of
+the process.
 
 ```typescript
 import { resetSeederFactoryManager } from 'typeorm-extension';

--- a/docs/guide/seeding.md
+++ b/docs/guide/seeding.md
@@ -162,6 +162,11 @@ export default class UserSeeder implements Seeder {
 }
 ```
 
+Factories obtained through the `factoryManager` argument are bound to the data source of the
+current seeder run — `save()` and `saveMany()` persist there. A factory used outside a seeder
+run (e.g. via `useSeederFactory(User)`) falls back to the data source registered for the
+`default` alias (see [setDataSource](datasource-api-reference.md#setdatasource)).
+
 ## Execute
 
 Populate the database from the code base:

--- a/src/data-source/options/singleton.ts
+++ b/src/data-source/options/singleton.ts
@@ -1,40 +1,23 @@
 import type { DataSourceOptions } from 'typeorm';
+import { AsyncKeyedCache } from '../../runtime';
 import { buildDataSourceOptions } from './module';
 
-const instances : Record<string, DataSourceOptions> = {};
-const instancePromises : Record<string, Promise<DataSourceOptions>> = {};
+const instances = new AsyncKeyedCache<DataSourceOptions>();
 
 export function setDataSourceOptions(
     options: DataSourceOptions,
     alias?: string,
 ) {
-    instances[alias || 'default'] = options;
+    instances.set(alias || 'default', options);
 }
 
 export function hasDataSourceOptions(alias?: string) : boolean {
-    return Object.prototype.hasOwnProperty.call(instances, alias || 'default');
+    return instances.has(alias || 'default');
 }
 
 export async function useDataSourceOptions(alias?: string) : Promise<DataSourceOptions> {
-    alias = alias || 'default';
-
-    if (Object.prototype.hasOwnProperty.call(instances, alias)) {
-        return instances[alias];
-    }
-
-    /* istanbul ignore next */
-    if (!Object.prototype.hasOwnProperty.call(instancePromises, alias)) {
-        instancePromises[alias] = buildDataSourceOptions()
-            .catch((e) => {
-                if (alias) {
-                    delete instancePromises[alias];
-                }
-
-                throw e;
-            });
-    }
-
-    instances[alias] = await instancePromises[alias];
-
-    return instances[alias];
+    return instances.resolve(
+        alias || 'default',
+        async (existing) => existing || buildDataSourceOptions(),
+    );
 }

--- a/src/data-source/options/singleton.ts
+++ b/src/data-source/options/singleton.ts
@@ -1,22 +1,20 @@
 import type { DataSourceOptions } from 'typeorm';
-import { AsyncKeyedCache } from '../../runtime';
+import { useRuntimeRegistry } from '../../runtime';
 import { buildDataSourceOptions } from './module';
-
-const instances = new AsyncKeyedCache<DataSourceOptions>();
 
 export function setDataSourceOptions(
     options: DataSourceOptions,
     alias?: string,
 ) {
-    instances.set(alias || 'default', options);
+    useRuntimeRegistry().dataSourceOptions.set(alias || 'default', options);
 }
 
 export function hasDataSourceOptions(alias?: string) : boolean {
-    return instances.has(alias || 'default');
+    return useRuntimeRegistry().dataSourceOptions.has(alias || 'default');
 }
 
 export async function useDataSourceOptions(alias?: string) : Promise<DataSourceOptions> {
-    return instances.resolve(
+    return useRuntimeRegistry().dataSourceOptions.resolve(
         alias || 'default',
         async (existing) => existing || buildDataSourceOptions(),
     );

--- a/src/data-source/singleton.ts
+++ b/src/data-source/singleton.ts
@@ -1,28 +1,26 @@
 import { DataSource } from 'typeorm';
-import { AsyncKeyedCache } from '../runtime';
+import { useRuntimeRegistry } from '../runtime';
 import { useDataSourceOptions } from './options';
-
-const instances = new AsyncKeyedCache<DataSource>();
 
 export function setDataSource(
     dataSource: DataSource,
     alias?: string,
 ) {
-    instances.set(alias || 'default', dataSource);
+    useRuntimeRegistry().dataSources.set(alias || 'default', dataSource);
 }
 
 export function hasDataSource(alias?: string) : boolean {
-    return instances.has(alias || 'default');
+    return useRuntimeRegistry().dataSources.has(alias || 'default');
 }
 
 export function unsetDataSource(alias?: string) {
-    instances.unset(alias || 'default');
+    useRuntimeRegistry().dataSources.unset(alias || 'default');
 }
 
 export async function useDataSource(alias?: string) : Promise<DataSource> {
     const key = alias || 'default';
 
-    return instances.resolve(key, async (existing) => {
+    return useRuntimeRegistry().dataSources.resolve(key, async (existing) => {
         if (existing) {
             if (!existing.isInitialized) {
                 await existing.initialize();

--- a/src/data-source/singleton.ts
+++ b/src/data-source/singleton.ts
@@ -1,99 +1,41 @@
-import type { DataSourceOptions } from 'typeorm';
 import { DataSource } from 'typeorm';
+import { AsyncKeyedCache } from '../runtime';
 import { useDataSourceOptions } from './options';
 
-const instances : Record<string, DataSource> = {};
-
-const initializePromises : Record<string, Promise<DataSource>> = {};
-const optionsPromises: Record<string, Promise<DataSourceOptions>> = {};
+const instances = new AsyncKeyedCache<DataSource>();
 
 export function setDataSource(
     dataSource: DataSource,
     alias?: string,
 ) {
-    alias = alias || 'default';
-
-    instances[alias] = dataSource;
+    instances.set(alias || 'default', dataSource);
 }
 
 export function hasDataSource(alias?: string) : boolean {
-    alias = alias || 'default';
-
-    return Object.prototype.hasOwnProperty.call(instances, alias);
+    return instances.has(alias || 'default');
 }
 
 export function unsetDataSource(alias?: string) {
-    alias = alias || 'default';
-
-    if (Object.prototype.hasOwnProperty.call(instances, alias)) {
-        delete instances[alias];
-    }
-
-    /* istanbul ignore next */
-    if (Object.prototype.hasOwnProperty.call(optionsPromises, alias)) {
-        delete optionsPromises[alias];
-    }
-
-    /* istanbul ignore next */
-    if (Object.prototype.hasOwnProperty.call(initializePromises, alias)) {
-        delete initializePromises[alias];
-    }
+    instances.unset(alias || 'default');
 }
 
 export async function useDataSource(alias?: string) : Promise<DataSource> {
-    alias = alias || 'default';
+    const key = alias || 'default';
 
-    if (Object.prototype.hasOwnProperty.call(instances, alias)) {
-        if (!instances[alias].isInitialized) {
-            /* istanbul ignore next */
-            if (!Object.prototype.hasOwnProperty.call(initializePromises, alias)) {
-                initializePromises[alias] = instances[alias].initialize()
-                    .catch((e) => {
-                        if (alias) {
-                            delete initializePromises[alias];
-                        }
-
-                        throw e;
-                    });
+    return instances.resolve(key, async (existing) => {
+        if (existing) {
+            if (!existing.isInitialized) {
+                await existing.initialize();
             }
 
-            await initializePromises[alias];
+            return existing;
         }
 
-        return instances[alias];
-    }
+        const options = await useDataSourceOptions(key);
 
-    /* istanbul ignore next */
-    if (!Object.prototype.hasOwnProperty.call(optionsPromises, alias)) {
-        optionsPromises[alias] = useDataSourceOptions(alias)
-            .catch((e) => {
-                if (alias) {
-                    delete optionsPromises[alias];
-                }
+        const dataSource = new DataSource(options);
+        await dataSource.initialize();
 
-                throw e;
-            });
-    }
-
-    const options = await optionsPromises[alias];
-
-    const dataSource = new DataSource(options);
-
-    /* istanbul ignore next */
-    if (!Object.prototype.hasOwnProperty.call(initializePromises, alias)) {
-        initializePromises[alias] = dataSource.initialize()
-            .catch((e) => {
-                if (alias) {
-                    delete initializePromises[alias];
-                }
-
-                throw e;
-            });
-    }
-
-    await initializePromises[alias];
-
-    instances[alias] = dataSource;
-
-    return dataSource;
+        return dataSource;
+    });
 }

--- a/src/env/module.ts
+++ b/src/env/module.ts
@@ -6,6 +6,7 @@ import {
     readInt,
 } from 'envix';
 import type { DatabaseType } from 'typeorm/driver/types/DatabaseType';
+import { useRuntimeRegistry } from '../runtime';
 import { EnvironmentName, EnvironmentVariableName } from './constants';
 import type { Environment } from './type';
 import {
@@ -13,17 +14,16 @@ import {
     transformLogging,
 } from './utils';
 
-let instance : Environment | undefined;
-
 export function useEnv() : Environment;
 export function useEnv<K extends keyof Environment>(key: K) : Environment[K];
 export function useEnv(key?: string) : any {
-    if (typeof instance !== 'undefined') {
+    const registry = useRuntimeRegistry();
+    if (typeof registry.env !== 'undefined') {
         if (typeof key === 'string') {
-            return instance[key as keyof Environment];
+            return registry.env[key as keyof Environment];
         }
 
-        return instance;
+        return registry.env;
     }
 
     const output: Environment = {
@@ -166,17 +166,15 @@ export function useEnv(key?: string) : any {
         output.type = type as DatabaseType; // todo: maybe validation here
     }
 
-    instance = output;
+    registry.env = output;
 
     if (typeof key === 'string') {
         return output[key as keyof Environment];
     }
 
-    return instance;
+    return output;
 }
 
 export function resetEnv() {
-    if (typeof instance !== 'undefined') {
-        instance = undefined;
-    }
+    useRuntimeRegistry().env = undefined;
 }

--- a/src/runtime/cache.ts
+++ b/src/runtime/cache.ts
@@ -1,0 +1,64 @@
+export class AsyncKeyedCache<V> {
+    protected values : Map<string, V>;
+
+    protected pending : Map<string, Promise<V>>;
+
+    constructor() {
+        this.values = new Map();
+        this.pending = new Map();
+    }
+
+    has(key: string) : boolean {
+        return this.values.has(key);
+    }
+
+    get(key: string) : V | undefined {
+        return this.values.get(key);
+    }
+
+    set(key: string, value: V) : void {
+        this.values.set(key, value);
+        this.pending.delete(key);
+    }
+
+    unset(key: string) : void {
+        this.values.delete(key);
+        this.pending.delete(key);
+    }
+
+    clear() : void {
+        this.values.clear();
+        this.pending.clear();
+    }
+
+    /**
+     * Get or build the value for a key.
+     *
+     * Concurrent calls for the same key share one build; a failed build is
+     * evicted so the next call retries. The build callback receives the
+     * currently stored value (if any) and may return it unchanged.
+     */
+    async resolve(key: string, build: (existing?: V) => Promise<V>) : Promise<V> {
+        const existing = this.pending.get(key);
+        if (existing) {
+            return existing;
+        }
+
+        const promise : Promise<V> = build(this.values.get(key))
+            .then((value) => {
+                this.values.set(key, value);
+                return value;
+            })
+            .catch((e) => {
+                if (this.pending.get(key) === promise) {
+                    this.pending.delete(key);
+                }
+
+                throw e;
+            });
+
+        this.pending.set(key, promise);
+
+        return promise;
+    }
+}

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -1,0 +1,1 @@
+export * from './cache';

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -1,1 +1,2 @@
 export * from './cache';
+export * from './module';

--- a/src/runtime/module.ts
+++ b/src/runtime/module.ts
@@ -1,0 +1,31 @@
+import type { DataSource, DataSourceOptions } from 'typeorm';
+import type { Environment } from '../env/type';
+import type { SeederFactoryManager } from '../seeder/factory/manager';
+import { AsyncKeyedCache } from './cache';
+
+export class RuntimeRegistry {
+    public readonly dataSources = new AsyncKeyedCache<DataSource>();
+
+    public readonly dataSourceOptions = new AsyncKeyedCache<DataSourceOptions>();
+
+    public env : Environment | undefined;
+
+    public factories : SeederFactoryManager | undefined;
+
+    reset() : void {
+        this.dataSources.clear();
+        this.dataSourceOptions.clear();
+        this.env = undefined;
+        this.factories = undefined;
+    }
+}
+
+let instance : RuntimeRegistry | undefined;
+
+export function useRuntimeRegistry() : RuntimeRegistry {
+    if (typeof instance === 'undefined') {
+        instance = new RuntimeRegistry();
+    }
+
+    return instance;
+}

--- a/src/seeder/executor.ts
+++ b/src/seeder/executor.ts
@@ -3,12 +3,11 @@ import type { ObjectLiteral } from 'rapiq';
 import { MssqlParameter, Table } from 'typeorm';
 import type { DataSource, DataSourceOptions, QueryRunner } from 'typeorm';
 import type { MongoQueryRunner } from 'typeorm/driver/mongodb/MongoQueryRunner';
-import { setDataSource } from '../data-source';
 import { useEnv } from '../env';
 import { adjustFilePaths, readTSConfig, resolveFilePath } from '../utils';
 import type { TSConfig } from '../utils';
 import { SeederEntity } from './entity';
-import { prepareSeederFactories, useSeederFactoryManager } from './factory';
+import { SeederFactoryManager, prepareSeederFactories, useSeederFactoryManager } from './factory';
 import type { SeederExecutorOptions, SeederOptions, SeederPrepareElement } from './type';
 import { prepareSeederSeeds } from './utils';
 
@@ -22,8 +21,6 @@ export class SeederExecutor {
     constructor(dataSource: DataSource, options?: SeederExecutorOptions) {
         this.dataSource = dataSource;
         this.options = options || {};
-
-        setDataSource(dataSource);
 
         this.tableName = this.dataSourceOptions.seedTableName || 'seeds';
     }
@@ -119,7 +116,10 @@ export class SeederExecutor {
             `${all.length} seeds were found in the source code.`,
         );
 
-        const factoryManager = useSeederFactoryManager();
+        const factoryManager = new SeederFactoryManager({
+            items: useSeederFactoryManager().items,
+            dataSource: this.dataSource,
+        });
 
         const executed : SeederEntity[] = [];
 

--- a/src/seeder/factory/manager.ts
+++ b/src/seeder/factory/manager.ts
@@ -1,10 +1,17 @@
-import type { EntitySchema, ObjectType } from 'typeorm';
-import type { FactoryCallback, SeederFactoryItem } from './type';
+import type { DataSource, EntitySchema, ObjectType } from 'typeorm';
+import type { FactoryCallback, SeederFactoryItem, SeederFactoryManagerContext } from './type';
 import { getEntityName, hasOwnProperty } from '../../utils';
 import { SeederFactory } from './module';
 
 export class SeederFactoryManager {
-    public readonly items : Record<string, SeederFactoryItem> = {};
+    public readonly items : Record<string, SeederFactoryItem>;
+
+    public readonly dataSource : DataSource | undefined;
+
+    constructor(context: SeederFactoryManagerContext = {}) {
+        this.items = context.items || {};
+        this.dataSource = context.dataSource;
+    }
 
     set<O extends Record<string, any>, Meta = unknown>(
         entity: ObjectType<O> | EntitySchema<O>,
@@ -33,6 +40,7 @@ export class SeederFactoryManager {
             factoryFn: this.items[name].factoryFn,
             entity,
             name,
+            dataSource: this.dataSource,
         });
     }
 }

--- a/src/seeder/factory/module.ts
+++ b/src/seeder/factory/module.ts
@@ -64,7 +64,7 @@ export class SeederFactory<O extends Record<string, any>, Meta = unknown> {
         params?: Partial<O>,
         options?: SaveOptions,
     ) : Promise<O> {
-        const dataSource = await useDataSource();
+        const dataSource = this.context.dataSource || await useDataSource();
 
         const entity = await this.make(params, true);
         const entityManager = dataSource.getRepository(this.context.entity);
@@ -103,10 +103,15 @@ export class SeederFactory<O extends Record<string, any>, Meta = unknown> {
                 // @ts-ignore
                 value instanceof SeederFactory
             ) {
+                const factory = value as SeederFactory<any>;
+                if (this.context.dataSource && !factory.context.dataSource) {
+                    factory.context.dataSource = this.context.dataSource;
+                }
+
                 if (save) {
-                    entity[key] = await (value as SeederFactory<any>).save();
+                    entity[key] = await factory.save();
                 } else {
-                    entity[key] = await (value as SeederFactory<any>).make();
+                    entity[key] = await factory.make();
                 }
             }
 

--- a/src/seeder/factory/type.ts
+++ b/src/seeder/factory/type.ts
@@ -1,5 +1,5 @@
 import type { Faker } from '@faker-js/faker';
-import type { EntitySchema, ObjectType } from 'typeorm';
+import type { DataSource, EntitySchema, ObjectType } from 'typeorm';
 
 export type FactoryCallback<O, Meta = unknown> = (faker: Faker, meta: Meta) => O | Promise<O>;
 
@@ -11,5 +11,11 @@ export type SeederFactoryItem = {
 export type SeederFactoryContext<O, Meta = unknown> = {
     name: string,
     entity: ObjectType<O> | EntitySchema<O>,
-    factoryFn: FactoryCallback<O, Meta | undefined>
+    factoryFn: FactoryCallback<O, Meta | undefined>,
+    dataSource?: DataSource
+};
+
+export type SeederFactoryManagerContext = {
+    items?: Record<string, SeederFactoryItem>,
+    dataSource?: DataSource
 };

--- a/src/seeder/factory/utils.ts
+++ b/src/seeder/factory/utils.ts
@@ -1,19 +1,17 @@
 import { load } from 'locter';
 import type { EntitySchema, ObjectType } from 'typeorm';
+import { useRuntimeRegistry } from '../../runtime';
 import { resolveFilePaths, resolveFilePatterns } from '../utils';
 import { SeederFactoryManager } from './manager';
 import type { FactoryCallback, SeederFactoryItem } from './type';
 
-let instance : SeederFactoryManager | undefined;
-
 export function useSeederFactoryManager() {
-    if (typeof instance !== 'undefined') {
-        return instance;
+    const registry = useRuntimeRegistry();
+    if (typeof registry.factories === 'undefined') {
+        registry.factories = new SeederFactoryManager();
     }
 
-    instance = new SeederFactoryManager();
-
-    return instance;
+    return registry.factories;
 }
 
 export function setSeederFactory<O extends Record<string, any>, Meta = unknown>(

--- a/src/seeder/factory/utils.ts
+++ b/src/seeder/factory/utils.ts
@@ -14,6 +14,10 @@ export function useSeederFactoryManager() {
     return registry.factories;
 }
 
+export function resetSeederFactoryManager() {
+    useRuntimeRegistry().factories = undefined;
+}
+
 export function setSeederFactory<O extends Record<string, any>, Meta = unknown>(
     entity: ObjectType<O> | EntitySchema<O>,
     factoryFn: FactoryCallback<O, Meta>,

--- a/test/unit/data-source/singleton.spec.ts
+++ b/test/unit/data-source/singleton.spec.ts
@@ -2,9 +2,11 @@ import { dataSource } from '../../data/typeorm/data-source';
 import {
     hasDataSource,
     setDataSource,
+    setDataSourceOptions,
     unsetDataSource,
     useDataSource,
 } from '../../../src';
+import { createDataSourceOptions } from '../../data/typeorm/factory';
 
 describe('src/data-source/singleton.ts', () => {
     afterAll(async () => {
@@ -41,5 +43,20 @@ describe('src/data-source/singleton.ts', () => {
 
         unsetDataSource('foo');
         expect(hasDataSource('foo')).toBeFalsy();
+    });
+
+    it('should build one data-source for concurrent calls', async () => {
+        setDataSourceOptions(createDataSourceOptions(), 'concurrent');
+
+        const [first, second] = await Promise.all([
+            useDataSource('concurrent'),
+            useDataSource('concurrent'),
+        ]);
+
+        expect(first).toBe(second);
+        expect(first.isInitialized).toBeTruthy();
+
+        await first.destroy();
+        unsetDataSource('concurrent');
     });
 });

--- a/test/unit/runtime/cache.spec.ts
+++ b/test/unit/runtime/cache.spec.ts
@@ -1,0 +1,123 @@
+import { AsyncKeyedCache } from '../../../src/runtime';
+
+describe('src/runtime/cache.ts', () => {
+    it('should set, get and unset values', () => {
+        const cache = new AsyncKeyedCache<string>();
+
+        expect(cache.has('foo')).toBeFalsy();
+        expect(cache.get('foo')).toBeUndefined();
+
+        cache.set('foo', 'bar');
+
+        expect(cache.has('foo')).toBeTruthy();
+        expect(cache.get('foo')).toEqual('bar');
+        expect(cache.has('baz')).toBeFalsy();
+
+        cache.unset('foo');
+
+        expect(cache.has('foo')).toBeFalsy();
+    });
+
+    it('should build and store a missing value', async () => {
+        const cache = new AsyncKeyedCache<string>();
+
+        const value = await cache.resolve('foo', async () => 'bar');
+
+        expect(value).toEqual('bar');
+        expect(cache.has('foo')).toBeTruthy();
+        expect(cache.get('foo')).toEqual('bar');
+    });
+
+    it('should pass the existing value to the build callback', async () => {
+        const cache = new AsyncKeyedCache<string>();
+        cache.set('foo', 'bar');
+
+        const value = await cache.resolve('foo', async (existing) => existing || 'baz');
+
+        expect(value).toEqual('bar');
+    });
+
+    it('should build once for concurrent calls', async () => {
+        const cache = new AsyncKeyedCache<number>();
+
+        let calls = 0;
+        const build = async () => {
+            calls++;
+            await new Promise((resolve) => {
+                setTimeout(resolve, 0);
+            });
+            return calls;
+        };
+
+        const [first, second] = await Promise.all([
+            cache.resolve('foo', build),
+            cache.resolve('foo', build),
+        ]);
+
+        expect(calls).toEqual(1);
+        expect(first).toEqual(1);
+        expect(second).toEqual(1);
+    });
+
+    it('should isolate values by key', async () => {
+        const cache = new AsyncKeyedCache<string>();
+
+        await cache.resolve('foo', async () => 'foo-value');
+        await cache.resolve('bar', async () => 'bar-value');
+
+        expect(cache.get('foo')).toEqual('foo-value');
+        expect(cache.get('bar')).toEqual('bar-value');
+
+        cache.unset('foo');
+
+        expect(cache.has('foo')).toBeFalsy();
+        expect(cache.has('bar')).toBeTruthy();
+    });
+
+    it('should evict a failed build and retry', async () => {
+        const cache = new AsyncKeyedCache<string>();
+
+        let calls = 0;
+        const build = async () => {
+            calls++;
+            if (calls === 1) {
+                throw new Error('boom');
+            }
+
+            return 'bar';
+        };
+
+        await expect(cache.resolve('foo', build)).rejects.toThrow('boom');
+        expect(cache.has('foo')).toBeFalsy();
+
+        const value = await cache.resolve('foo', build);
+        expect(value).toEqual('bar');
+        expect(calls).toEqual(2);
+    });
+
+    it('should resolve with the replacement after set', async () => {
+        const cache = new AsyncKeyedCache<string>();
+
+        cache.set('foo', 'bar');
+
+        const value = await cache.resolve('foo', async (existing) => existing as string);
+        expect(value).toEqual('bar');
+
+        cache.set('foo', 'baz');
+
+        const next = await cache.resolve('foo', async (existing) => existing as string);
+        expect(next).toEqual('baz');
+    });
+
+    it('should clear all values and pending builds', async () => {
+        const cache = new AsyncKeyedCache<string>();
+
+        await cache.resolve('foo', async () => 'bar');
+        cache.set('baz', 'qux');
+
+        cache.clear();
+
+        expect(cache.has('foo')).toBeFalsy();
+        expect(cache.has('baz')).toBeFalsy();
+    });
+});

--- a/test/unit/runtime/module.spec.ts
+++ b/test/unit/runtime/module.spec.ts
@@ -1,0 +1,54 @@
+import { useEnv } from '../../../src/env';
+import { useRuntimeRegistry } from '../../../src/runtime';
+import {
+    hasDataSource,
+    hasDataSourceOptions,
+    setDataSource,
+    setDataSourceOptions,
+    useSeederFactoryManager,
+} from '../../../src';
+import { dataSource } from '../../data/typeorm/data-source';
+
+describe('src/runtime/module.ts', () => {
+    afterEach(() => {
+        useRuntimeRegistry().reset();
+    });
+
+    it('should return the same registry instance', () => {
+        expect(useRuntimeRegistry()).toBe(useRuntimeRegistry());
+    });
+
+    it('should hold state of the singleton accessors', () => {
+        const registry = useRuntimeRegistry();
+
+        setDataSource(dataSource, 'foo');
+        expect(registry.dataSources.has('foo')).toBeTruthy();
+
+        setDataSourceOptions(dataSource.options, 'foo');
+        expect(registry.dataSourceOptions.has('foo')).toBeTruthy();
+
+        useEnv();
+        expect(registry.env).toBeDefined();
+
+        const manager = useSeederFactoryManager();
+        expect(registry.factories).toBe(manager);
+    });
+
+    it('should restore a pristine state on reset', () => {
+        const registry = useRuntimeRegistry();
+
+        setDataSource(dataSource);
+        setDataSourceOptions(dataSource.options);
+        useEnv();
+        const manager = useSeederFactoryManager();
+
+        registry.reset();
+
+        expect(hasDataSource()).toBeFalsy();
+        expect(hasDataSourceOptions()).toBeFalsy();
+        expect(registry.env).toBeUndefined();
+        expect(registry.factories).toBeUndefined();
+
+        expect(useSeederFactoryManager()).not.toBe(manager);
+    });
+});

--- a/test/unit/seeder/factory.spec.ts
+++ b/test/unit/seeder/factory.spec.ts
@@ -1,5 +1,11 @@
 import type { DataSource } from 'typeorm';
-import { useSeederFactory } from '../../../src';
+import {
+    resetSeederFactoryManager,
+    setSeederFactory,
+    useSeederFactory,
+    useSeederFactoryManager,
+} from '../../../src';
+import { Role } from '../../data/entity/role';
 import { User } from '../../data/entity/user';
 import { destroyTestFsDataSource, setupFsDataSource } from '../../data/typeorm/utils';
 import '../../data/factory/user';
@@ -38,5 +44,18 @@ describe('src/seeder/factory/index.ts', () => {
         factory.setLocale('de');
         user = await factory.save();
         expect(user).toBeDefined();
+    });
+
+    it('should reset the factory manager', () => {
+        setSeederFactory(Role, () => new Role());
+
+        const manager = useSeederFactoryManager();
+        expect(manager.items.Role).toBeDefined();
+
+        resetSeederFactoryManager();
+
+        const next = useSeederFactoryManager();
+        expect(next).not.toBe(manager);
+        expect(next.items.Role).toBeUndefined();
     });
 });

--- a/test/unit/seeder/seeder.spec.ts
+++ b/test/unit/seeder/seeder.spec.ts
@@ -1,11 +1,15 @@
-import type { DataSource } from 'typeorm';
+import { DataSource } from 'typeorm';
 import {
     SeederExecutor,
+    createDatabase,
+    dropDatabase,
     runSeeder,
     runSeeders,
+    useDataSource,
 } from '../../../src';
 import type { SeederEntity } from '../../../src';
 import { User } from '../../data/entity/user';
+import { createDataSourceOptions } from '../../data/typeorm/factory';
 import { destroyTestFsDataSource, setupFsDataSource } from '../../data/typeorm/utils';
 import '../../data/factory/user';
 import UserSeeder from '../../data/seed/user';
@@ -44,6 +48,36 @@ describe('src/seeder/index.ts', () => {
 
         expect(entities).toBeDefined();
         expect(entities.length).toBeGreaterThanOrEqual(7);
+    });
+
+    it('should not touch the default alias and seed into the executor data-source', async () => {
+        const options = createDataSourceOptions();
+        Object.assign(options, { database: 'writable/seeder-secondary.sqlite' });
+
+        await createDatabase({ options });
+
+        const secondary = new DataSource(options);
+        await secondary.initialize();
+
+        try {
+            const executor = new SeederExecutor(secondary);
+
+            // constructing an executor must not repoint the default alias
+            const defaultDataSource = await useDataSource();
+            expect(defaultDataSource).toBe(dataSource);
+
+            await executor.execute({ seeds: [UserSeeder] });
+
+            // factory saves belong to the executor's data-source, not the default one
+            const secondaryCount = await secondary.getRepository(User).count();
+            expect(secondaryCount).toBeGreaterThanOrEqual(7);
+
+            const defaultCount = await dataSource.getRepository(User).count();
+            expect(defaultCount).toEqual(0);
+        } finally {
+            await secondary.destroy();
+            await dropDatabase({ options });
+        }
     });
 
     it('should seed with explicit definition', async () => {


### PR DESCRIPTION
## Summary

Phase 1 of the architecture roadmap ([plan 002](https://github.com/tada5hi/typeorm-extension/blob/master/.agents/plans/002-runtime-registry.md)): consolidate the four independently-invented mutable module stores into one runtime registry, and remove the `SeederExecutor` constructor's hidden `setDataSource()` write — the breaking behavior fix that needs to land inside the v4 beta window.

### `refactor: extract a shared async keyed cache for singleton state`

`src/data-source/singleton.ts` and `src/data-source/options/singleton.ts` each hand-rolled the same memoize-with-promise-cache idiom. `AsyncKeyedCache` (`src/runtime/cache.ts`) implements it once: concurrent `resolve()` calls share one build, failed builds are evicted for retry, and `set()` clears pending builds so a replaced value can't be shadowed by a stale promise.

This also closes two latent races in the old code:
- concurrent `useDataSource()` calls for an unregistered alias each constructed their own `DataSource`, and the last (uninitialized) one won the instance slot;
- `setDataSource()` after a completed initialization left a stale resolved promise, so a replacement instance was returned uninitialized.

### `refactor: consolidate singleton state into a runtime registry`

`RuntimeRegistry` (`src/runtime/module.ts`, internal — not in the public barrel) owns the data-source cache, the options cache, the memoized environment and the seeder factory manager, with a uniform `reset()`. All public accessors (`setDataSource`/`useDataSource`, `useEnv`/`resetEnv`, `useSeederFactoryManager`, …) are unchanged, delegating to the registry.

### `fix!: stop registering the executor data source as the global default` ⚠️

`new SeederExecutor(dataSource)` called `setDataSource(dataSource)`, silently repointing the `'default'` alias — so constructing an executor for data source B redirected every subsequent factory `.save()` elsewhere in the process. The executor now hands each run a factory manager bound to its own data source (sharing the globally registered factory items); nested factories inherit the binding. Factories used outside a run keep resolving the default alias.

**BREAKING CHANGE**: `new SeederExecutor(dataSource)` / `runSeeder(s)` no longer register the data source under the `'default'` alias — call `setDataSource()` explicitly if you relied on that (documented in the v4 migration guide).

### `feat: add reset for the seeder factory manager`

`resetSeederFactoryManager()` — registrations previously accumulated for the process lifetime with no way to clear them.

## Tests

- `test/unit/runtime/cache.spec.ts` — cache semantics: concurrent dedupe, failure eviction/retry, set/unset/clear.
- `test/unit/runtime/module.spec.ts` — registry state held for all accessors, pristine `reset()`.
- Seeder regression: an executor for a secondary data source leaves `useDataSource('default')` untouched and factory saves land in the executor's database.
- Concurrent `useDataSource()` builds exactly one instance.
- Coverage gate passes with `src/runtime/**` in the denominator (100% stmts on the new module).

## Docs

Agent docs (structure/architecture/testing), v4 migration guide entry, seeding guide + README factory-binding semantics, `resetSeederFactoryManager` API reference.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added centralized runtime state management for data sources, options, environment settings, and seeder factories.
  * Added concurrency-safe data source creation and a public runtime reset capability.
  * Added `resetSeederFactoryManager()` for clearing registered factory definitions.

* **Bug Fixes**
  * Concurrent data source requests now reuse a single initialized instance.
  * Seeder factories persist data to the executor’s data source without changing the default alias.

* **Documentation**
  * Updated architecture, testing, seeding, and migration guidance, including the v4 data-source behavior change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->