### PR TITLE
feat!: pure seeder-config resolver + SeederExecutor decomposition

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -58,7 +58,7 @@ The peer-dep range is `typeorm ^1.0.0`. TypeORM 0.3 is **not** supported on `typ
 
 ### 5. Seeder tracking mirrors TypeORM's migration tracking
 
-`SeederExecutor` (`src/seeder/executor.ts`) follows the same shape as TypeORM's `MigrationExecutor`: a `seeds` table with `id`, `timestamp`, `name`, populated only when tracking is enabled (per-seed `track = true` or executor-level `seedTracking: true`). MongoDB uses a collection instead. Untracked seeds re-run on every invocation.
+`SeederExecutor` (`src/seeder/executor.ts`) follows the same shape as TypeORM's `MigrationExecutor`: a `seeds` table with `id`, `timestamp`, `name`, populated only when tracking is enabled (per-seed `track = true` or executor-level `seedTracking`, resolved from input ← data-source options). MongoDB uses a collection instead. Untracked seeds re-run on every invocation. The per-seed decision lives in `SeederEntity.effectiveTracking(fallback)`; execution order in the static `SeederEntity.compare` comparator. The table name comes from `seedTableName` (input ← data-source options ← `'seeds'`).
 
 ## Design Patterns
 
@@ -165,15 +165,18 @@ Output:
 
 ```
 Input:
-  └── DataSource + SeederOptions { seeds, factories, seedName?, seedTracking? }
+  └── DataSource + SeederOptions { seeds, factories, seedName?, seedTableName?, seedTracking? }
 
-Processing:
-  1. SeederExecutor.buildOptions() merges options ← dataSource.options ← env ← defaults
-  2. (optional) prepareSeederFactories() loads factory files via glob → registers in the global manager
-  3. prepareSeederSeeds() loads seed files via glob → constructs entities
-  4. If tracking: create `seeds` table if missing, load already-executed names
-  5. Filter to pending = (matches seedName?) AND (not already tracked OR not tracking)
-  6. For each pending: instantiate, call .run(dataSource, factoryManager) with a manager bound to
+Processing (SeederExecutor.execute — one named stage per step):
+  1. resolveConfig(): pure resolveSeederConfig(input, dataSource.options, env) — precedence
+     input ← dataSource.options ← env ← defaults (src/seeder/config.ts) — then JIT path adjustment
+  2. prepareSeederFactories() loads factory files via glob → registers in the global manager
+  3. loadEntities(): prepareSeederSeeds() loads seed files via glob → SeederEntity list,
+     ordered by SeederEntity.compare (fileName, then timestamp)
+  4. If tracking: create the seedTableName table if missing, load already-executed names
+  5. filterPending(): (matches seedName?) AND (not already tracked OR not
+     SeederEntity.effectiveTracking(seedTracking))
+  6. runPending(): instantiate, call .run(dataSource, factoryManager) with a manager bound to
      the executor's data source, optionally insert tracking row
 
 Output:
@@ -224,6 +227,7 @@ DataSource registry      → src/data-source/singleton.ts (delegates to src/runt
 DataSource discovery     → src/data-source/find/module.ts
 DataSource options merge → src/data-source/options/module.ts + utils/{env,merge}.ts
 Seeder runtime           → src/seeder/executor.ts, src/seeder/module.ts
+Seeder config resolver   → src/seeder/config.ts (resolveSeederConfig)
 Factory registry         → src/seeder/factory/manager.ts
 Query applier            → src/query/module.ts
 Per-parameter appliers   → src/query/parameter/<concern>/module.ts

--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -17,7 +17,7 @@
 
 - **Validation**: no schema-validation library is used. Public API functions take loose input objects and trust internal callers.
 - **Errors**: typed via `TypeormExtensionError` → `DriverError` / `OptionsError` (`src/errors/`). Throw a typed error only when a consumer might reasonably want to catch it (e.g. unsupported driver, missing data source). Otherwise let TypeORM / native-driver errors propagate.
-- **Validation location**: context-builder functions (`buildDatabaseCreateContext`, `buildDataSourceOptions`, `SeederExecutor.buildOptions`) are the choke points where defaults are applied and missing values raise `OptionsError`.
+- **Validation location**: context-builder functions (`buildDatabaseCreateContext`, `buildDataSourceOptions`, `resolveSeederConfig`) are the choke points where defaults are applied and missing values raise `OptionsError`.
 
 ## Workflow
 

--- a/.agents/structure.md
+++ b/.agents/structure.md
@@ -39,7 +39,8 @@ typeorm-extension/
 │   │   ├── cache.ts            # AsyncKeyedCache — keyed get-or-build with concurrent dedupe
 │   │   └── module.ts           # RuntimeRegistry + useRuntimeRegistry() — owns data sources, options, env, factories
 │   ├── seeder/                 # Seeder + factory runtime
-│   │   ├── executor.ts         # SeederExecutor — orchestrates run + tracking table
+│   │   ├── config.ts           # resolveSeederConfig — pure precedence resolver (input ← ds options ← env ← defaults)
+│   │   ├── executor.ts         # SeederExecutor — named pipeline stages + tracking table
 │   │   ├── module.ts           # runSeeder / runSeeders
 │   │   ├── factory/            # SeederFactory + SeederFactoryManager (faker bridge)
 │   │   └── utils/              # template, file path resolution, glob prep

--- a/.agents/testing.md
+++ b/.agents/testing.md
@@ -108,7 +108,7 @@ Thresholds (enforced — Vitest fails the run below these):
 | lines      | 80%    |
 | statements | 80%    |
 
-`coverage.exclude` (in `test/vitest.config.ts`) **excludes** `src/cli/**`, `src/database/adapters/**`, `src/database/driver/**` (deprecated delegates), `src/env/utils.ts`, `src/errors/**`, `src/utils/**`, and `src/seeder/**` from coverage scoring — the gate covers `src/data-source/**`, `src/helpers/**`, `src/query/**`, and the database layer (`core/`, `registry.ts`, `methods/`, `utils/`). Be aware: a change inside the excluded folders won't be caught by the threshold, so write tests proactively for those.
+`coverage.exclude` (in `test/vitest.config.ts`) **excludes** `src/cli/**`, `src/database/adapters/**`, `src/database/driver/**` (deprecated delegates), `src/env/utils.ts`, `src/errors/**`, and `src/utils/**` from coverage scoring — the gate covers `src/data-source/**`, `src/helpers/**`, `src/query/**`, `src/seeder/**`, and the database layer (`core/`, `registry.ts`, `methods/`, `utils/`). Be aware: a change inside the excluded folders won't be caught by the threshold, so write tests proactively for those.
 
 Coverage is uploaded by CI to Codecov via `codecov/codecov-action`.
 

--- a/README.MD
+++ b/README.MD
@@ -328,8 +328,14 @@ The following values are assumed by default:
 
 Note: When seeder paths are configured as **glob patterns**, the paths are resolved and sorted in alphabetical order using filenames. This helps to ensure that the seeders are executed in the correct order.
 
+Seeder options can be provided per invocation (`runSeeder(s)` options parameter), on the extended
+data-source options, or via environment variables. Explicit input wins over the data-source options,
+which win over the environment; built-in defaults apply last.
+
 It is possible to define that a seeder is only executed once.
 This can either be set globally using the `seedTracking` option or locally using the `track` property of a seeder class.
+Executed seeds are recorded in a `seeds` table (a collection for MongoDB);
+the table name can be changed with the `seedTableName` option.
 
 `data-source.ts`
 

--- a/docs/guide/seeding-api-reference.md
+++ b/docs/guide/seeding-api-reference.md
@@ -4,13 +4,14 @@
 
 ```typescript
 declare function runSeeder(
-    dataSource: DataSource, 
-    seeder: SeederConstructor, 
-    options: SeederOptions
-) : Promise<vod>;
+    dataSource: DataSource,
+    seeder: SeederConstructor | string,
+    options?: SeederOptions
+) : Promise<SeederEntity | undefined>;
 ```
 
-Populate the database with a specific seeder.
+Populate the database with a specific seeder, referenced by constructor or by name
+(class name, file name or file path).
 
 **Example: Simple**
 
@@ -67,15 +68,15 @@ class SimpleSeeder implements Seeder {
 
 **Parameters**
 
-| Name         | Type                 | Description                                                                         |
-|:-------------|:---------------------|:------------------------------------------------------------------------------------|
-| `dataSource` | `DataSource`         | Typeorm DataSource Object                                                           |
-| `seeder`     | `SeederConstructor`  | A class which implements the Seeder Interface.                                      |
-| `options`    | `SeederOptions`      | Seeding options to provide or overwrite the default ones. [Details](#seederoptions) |
+| Name         | Type                          | Description                                                                         |
+|:-------------|:------------------------------|:------------------------------------------------------------------------------------|
+| `dataSource` | `DataSource`                  | Typeorm DataSource Object                                                           |
+| `seeder`     | `SeederConstructor` \| `string` | A class which implements the Seeder Interface, or a seeder name.                  |
+| `options`    | `SeederOptions`               | Seeding options to provide or overwrite the default ones. [Details](#seederoptions) |
 
 **Returns**
 
-`Promise`<`void`>
+`Promise`<`SeederEntity` | `undefined`>
 
 **References**
 - [SeederConstructor](#seederconstructor)
@@ -85,9 +86,9 @@ class SimpleSeeder implements Seeder {
 
 ```typescript
 declare function runSeeders(
-    dataSource: DataSource, 
-    options: SeederOptions
-) : Promise<void>;
+    dataSource: DataSource,
+    options?: SeederOptions
+) : Promise<SeederEntity[]>;
 ```
 
 Populate the database.
@@ -137,7 +138,7 @@ import { runSeeders } from 'typeorm-extension';
 
 **Returns**
 
-`Promise`<`void`>
+`Promise`<`SeederEntity[]`>
 
 **References**
 - [SeederOptions](#seederoptions)
@@ -173,6 +174,39 @@ export type SeederOptions = {
     factories?: SeederFactoryItem[] | string[],
 };
 ```
+
+## `resolveSeederConfig`
+
+```typescript
+declare function resolveSeederConfig(
+    input?: SeederOptions,
+    dataSourceOptions?: SeederOptions,
+    env?: { seeds: string[], factories: string[] }
+) : SeederConfig;
+```
+
+Resolve the effective seeder configuration. A pure function: explicit input wins over the
+data-source options, which win over the environment values; built-in defaults apply last.
+The seeder runtime uses it internally — it is exported for consumers who want to inspect
+the effective configuration (e.g. in a custom CLI).
+
+## `SeederConfig`
+
+```typescript
+import { SeederConstructor, SeederFactoryItem } from 'typeorm-extension';
+
+export type SeederConfig = {
+    seeds: SeederConstructor[] | string[],
+    seedName?: string,
+    seedTableName: string,
+    seedTracking: boolean,
+
+    factories: SeederFactoryItem[] | string[],
+};
+```
+
+The fully resolved counterpart of [SeederOptions](#seederoptions): no optional
+seeds/factories/tracking fields, defaults already applied.
 
 ## `resetSeederFactoryManager`
 

--- a/docs/guide/seeding-api-reference.md
+++ b/docs/guide/seeding-api-reference.md
@@ -162,14 +162,15 @@ type SeederConstructor = new () => Seeder;
 ## `SeederOptions`
 
 ```typescript
-import { SeederConstructor, SeederFactoryConfig } from 'typeorm-extension';
+import { SeederConstructor, SeederFactoryItem } from 'typeorm-extension';
 
 export type SeederOptions = {
     seeds?: SeederConstructor[] | string[],
     seedName?: string,
+    seedTableName?: string,
+    seedTracking?: boolean,
 
-    factories?: SeederFactoryConfig[] | string[],
-    factoriesLoad?: boolean
+    factories?: SeederFactoryItem[] | string[],
 };
 ```
 

--- a/docs/guide/seeding.md
+++ b/docs/guide/seeding.md
@@ -28,6 +28,15 @@ The following values are assumed by default:
 - factory path: `src/database/factories/**/*{.ts,.js}`
 - seed path: `src/database/seeds/**/*{.ts,.js}`
 
+Seeder options can be provided per invocation (`runSeeder(s)` options parameter), on the extended
+data-source options, or via environment variables. Explicit input wins over the data-source options,
+which win over the environment; built-in defaults apply last.
+
+It is possible to define that a seeder is only executed once.
+This can either be set globally using the `seedTracking` option or locally using the `track`
+property of a seeder class. Executed seeds are recorded in a `seeds` table (a collection for
+MongoDB); the table name can be changed with the `seedTableName` option.
+
 `env`
 ```
 TYPEORM_SEEDING_FACTORIES=src/database/factories/**/*{.ts,.js}

--- a/src/seeder/config.ts
+++ b/src/seeder/config.ts
@@ -24,7 +24,9 @@ export function resolveSeederConfig(
         seedTableName: input.seedTableName ||
             dataSourceOptions.seedTableName ||
             'seeds',
-        seedTracking: input.seedTracking ?? false,
+        seedTracking: input.seedTracking ??
+            dataSourceOptions.seedTracking ??
+            false,
         factories: firstNonEmpty(input.factories, dataSourceOptions.factories, env.factories) ??
             FACTORIES_DEFAULT,
     };

--- a/src/seeder/config.ts
+++ b/src/seeder/config.ts
@@ -21,7 +21,9 @@ export function resolveSeederConfig(
         seeds: firstNonEmpty(input.seeds, dataSourceOptions.seeds, env.seeds) ??
             SEEDS_DEFAULT,
         seedName: input.seedName,
-        seedTableName: dataSourceOptions.seedTableName || 'seeds',
+        seedTableName: input.seedTableName ||
+            dataSourceOptions.seedTableName ||
+            'seeds',
         seedTracking: input.seedTracking ?? false,
         factories: firstNonEmpty(input.factories, dataSourceOptions.factories, env.factories) ??
             FACTORIES_DEFAULT,

--- a/src/seeder/config.ts
+++ b/src/seeder/config.ts
@@ -1,0 +1,29 @@
+import type { Environment } from '../env';
+import type { SeederConfig, SeederOptions } from './type';
+
+const SEEDS_DEFAULT = ['src/database/seeds/**/*{.ts,.js}'];
+const FACTORIES_DEFAULT = ['src/database/factories/**/*{.ts,.js}'];
+
+function firstNonEmpty<T extends unknown[]>(
+    ...candidates: (T | undefined)[]
+) : T | undefined {
+    return candidates.find(
+        (candidate) => typeof candidate !== 'undefined' && candidate.length > 0,
+    );
+}
+
+export function resolveSeederConfig(
+    input: SeederOptions = {},
+    dataSourceOptions: SeederOptions = {},
+    env: Pick<Environment, 'seeds' | 'factories'> = { seeds: [], factories: [] },
+) : SeederConfig {
+    return {
+        seeds: firstNonEmpty(input.seeds, dataSourceOptions.seeds, env.seeds) ??
+            SEEDS_DEFAULT,
+        seedName: input.seedName,
+        seedTableName: dataSourceOptions.seedTableName || 'seeds',
+        seedTracking: input.seedTracking ?? false,
+        factories: firstNonEmpty(input.factories, dataSourceOptions.factories, env.factories) ??
+            FACTORIES_DEFAULT,
+    };
+}

--- a/src/seeder/entity.ts
+++ b/src/seeder/entity.ts
@@ -81,7 +81,8 @@ export class SeederEntity {
     static compare(a: SeederEntity, b: SeederEntity) : number {
         if (
             typeof a.fileName !== 'undefined' &&
-            typeof b.fileName !== 'undefined'
+            typeof b.fileName !== 'undefined' &&
+            a.fileName !== b.fileName
         ) {
             return a.fileName > b.fileName ? 1 : -1;
         }

--- a/src/seeder/entity.ts
+++ b/src/seeder/entity.ts
@@ -65,4 +65,27 @@ export class SeederEntity {
 
         return this.instance.track;
     }
+
+    /**
+     * Decide whether this seeder's execution should be tracked.
+     * The per-seed track property wins over the executor-level default.
+     */
+    effectiveTracking(fallback: boolean) : boolean {
+        return this.trackExecution ?? fallback;
+    }
+
+    /**
+     * Execution-order comparator:
+     * by file name when both entities are file-backed, by timestamp otherwise.
+     */
+    static compare(a: SeederEntity, b: SeederEntity) : number {
+        if (
+            typeof a.fileName !== 'undefined' &&
+            typeof b.fileName !== 'undefined'
+        ) {
+            return a.fileName > b.fileName ? 1 : -1;
+        }
+
+        return a.timestamp - b.timestamp;
+    }
 }

--- a/src/seeder/executor.ts
+++ b/src/seeder/executor.ts
@@ -22,13 +22,9 @@ export class SeederExecutor {
 
     protected options : SeederExecutorOptions;
 
-    private readonly tableName: string;
-
     constructor(dataSource: DataSource, options?: SeederExecutorOptions) {
         this.dataSource = dataSource;
         this.options = options || {};
-
-        this.tableName = this.dataSourceOptions.seedTableName || 'seeds';
     }
 
     async execute(input: SeederOptions = {}) : Promise<SeederEntity[]> {
@@ -57,8 +53,8 @@ export class SeederExecutor {
 
         if (tracking) {
             queryRunner = this.dataSource.createQueryRunner();
-            await this.createTableIfNotExist(queryRunner);
-            existing = await this.loadExisting(queryRunner);
+            await this.createTableIfNotExist(queryRunner, options.seedTableName);
+            existing = await this.loadExisting(queryRunner, options.seedTableName);
         }
 
         const isMatch = (seed: SeederEntity) : boolean => {
@@ -146,7 +142,7 @@ export class SeederExecutor {
                 }
 
                 if (queryRunner && seedTracking) {
-                    await this.track(queryRunner, element);
+                    await this.track(queryRunner, element, options.seedTableName);
                 }
 
                 this.dataSource.logger.logSchemaBuild(
@@ -164,12 +160,15 @@ export class SeederExecutor {
         return executed;
     }
 
-    protected async loadExisting(queryRunner: QueryRunner) : Promise<SeederEntity[]> {
+    protected async loadExisting(
+        queryRunner: QueryRunner,
+        tableName: string,
+    ) : Promise<SeederEntity[]> {
         if (this.dataSource.driver.options.type === 'mongodb') {
             const mongoRunner = queryRunner as MongoQueryRunner;
 
             return mongoRunner
-                .cursor(this.tableName, {})
+                .cursor(tableName, {})
                 .sort({ _id: -1 })
                 .toArray();
         }
@@ -178,7 +177,7 @@ export class SeederExecutor {
             .createQueryBuilder(queryRunner)
             .select()
             .orderBy(this.dataSource.driver.escape('id'), 'DESC')
-            .from(this.table, this.tableName)
+            .from(this.buildTableName(tableName), tableName)
             .getRawMany();
 
         return raw.map((migrationRaw) => new SeederEntity({
@@ -255,18 +254,21 @@ export class SeederExecutor {
         }
     }
 
-    protected async createTableIfNotExist(queryRunner: QueryRunner) {
+    protected async createTableIfNotExist(
+        queryRunner: QueryRunner,
+        tableName: string,
+    ) {
         // If driver is mongo no need to create
         if (this.dataSource.driver.options.type === 'mongodb') {
             return;
         }
-        const tableExist = await queryRunner.hasTable(this.table);
+        const tableExist = await queryRunner.hasTable(this.buildTableName(tableName));
         if (!tableExist) {
             await queryRunner.createTable(
                 new Table({
                     database: this.database,
                     schema: this.schema,
-                    name: this.table,
+                    name: this.buildTableName(tableName),
                     columns: [
                         {
                             name: 'id',
@@ -305,6 +307,7 @@ export class SeederExecutor {
     protected async track(
         queryRunner: QueryRunner,
         seederEntity: SeederEntity,
+        tableName: string,
     ): Promise<void> {
         const values: ObjectLiteral = {};
         if (this.dataSource.driver.options.type === 'mssql') {
@@ -328,13 +331,13 @@ export class SeederExecutor {
             const mongoRunner = queryRunner as MongoQueryRunner;
             await mongoRunner.databaseConnection
                 .db(this.dataSource.driver.database)
-                .collection(this.tableName)
+                .collection(tableName)
                 .insertOne(values);
         } else {
             const qb = queryRunner.manager.createQueryBuilder();
             await qb
                 .insert()
-                .into(this.table)
+                .into(this.buildTableName(tableName))
                 .values(values)
                 .execute();
         }
@@ -352,9 +355,9 @@ export class SeederExecutor {
         return this.dataSource.driver.schema;
     }
 
-    protected get table() {
+    protected buildTableName(tableName: string) : string {
         return this.dataSource.driver.buildTableName(
-            this.tableName,
+            tableName,
             this.schema,
             this.database,
         );

--- a/src/seeder/executor.ts
+++ b/src/seeder/executor.ts
@@ -10,9 +10,9 @@ import { resolveSeederConfig } from './config';
 import { SeederEntity } from './entity';
 import { SeederFactoryManager, prepareSeederFactories, useSeederFactoryManager } from './factory';
 import type {
-    SeederConfig, 
-    SeederExecutorOptions, 
-    SeederOptions, 
+    SeederConfig,
+    SeederExecutorOptions,
+    SeederOptions,
     SeederPrepareElement,
 } from './type';
 import { prepareSeederSeeds } from './utils';
@@ -28,58 +28,89 @@ export class SeederExecutor {
     }
 
     async execute(input: SeederOptions = {}) : Promise<SeederEntity[]> {
-        const options = await this.buildOptions(input);
-        if (!options.seeds || options.seeds.length === 0) {
-            return [];
-        }
+        const config = await this.resolveConfig(input);
 
-        if (options.factories) {
-            await prepareSeederFactories(options.factories, this.options.root);
-        }
+        await prepareSeederFactories(config.factories, this.options.root);
 
-        const seederElements = await prepareSeederSeeds(
-            options.seeds,
-            this.options.root,
-        );
-        const all = await this.buildEntities(seederElements);
+        const all = await this.loadEntities(config);
 
-        const tracking = options.seedTracking ||
-            all.some((seed) => seed.effectiveTracking(options.seedTracking));
+        const tracking = config.seedTracking ||
+            all.some((seed) => seed.effectiveTracking(config.seedTracking));
 
         let queryRunner : QueryRunner | undefined;
         let existing : SeederEntity[] = [];
 
         if (tracking) {
             queryRunner = this.dataSource.createQueryRunner();
-            await this.createTableIfNotExist(queryRunner, options.seedTableName);
-            existing = await this.loadExisting(queryRunner, options.seedTableName);
+            await this.createTableIfNotExist(queryRunner, config.seedTableName);
+            existing = await this.loadExisting(queryRunner, config.seedTableName);
         }
 
-        const isMatch = (seed: SeederEntity) : boolean => {
-            if (!options.seedName) {
-                return true;
+        try {
+            const pending = this.filterPending(all, existing, config);
+            if (pending.length === 0) {
+                return [];
             }
 
-            if (
-                seed.name === options.seedName ||
-                seed.fileName === options.seedName
-            ) {
-                return true;
+            this.dataSource.logger.logSchemaBuild(
+                `${existing.length} seeds are already present in the database.`,
+            );
+            this.dataSource.logger.logSchemaBuild(
+                `${all.length} seeds were found in the source code.`,
+            );
+
+            return await this.runPending(pending, config, queryRunner);
+        } finally {
+            if (queryRunner) {
+                await queryRunner.release();
+            }
+        }
+    }
+
+    protected async resolveConfig(input: SeederOptions = {}) : Promise<SeederConfig> {
+        const config = resolveSeederConfig(input, this.dataSourceOptions, useEnv());
+
+        if (!this.options.preserveFilePaths) {
+            let tsConfig : TSConfig;
+
+            if (isObject(this.options.tsconfig)) {
+                tsConfig = this.options.tsconfig;
+            } else {
+                tsConfig = await readTSConfig(
+                    resolveFilePath(this.options.tsconfig || 'tsconfig.json', this.options.root),
+                );
             }
 
-            if (!seed.filePath) {
-                return false;
-            }
+            await adjustFilePaths(
+                config,
+                [
+                    'seeds',
+                    'seedName',
+                    'factories',
+                ],
+                tsConfig,
+            );
+        }
 
-            if (seed.filePath === options.seedName) {
-                return true;
-            }
+        return config;
+    }
 
-            return resolveFilePath(options.seedName, this.options.root) === seed.filePath;
-        };
+    protected async loadEntities(config: SeederConfig) : Promise<SeederEntity[]> {
+        const elements = await prepareSeederSeeds(
+            config.seeds,
+            this.options.root,
+        );
 
-        const pending = all.filter((seed) => {
-            if (!isMatch(seed)) {
+        return this.buildEntities(elements);
+    }
+
+    protected filterPending(
+        all: SeederEntity[],
+        existing: SeederEntity[],
+        config: SeederConfig,
+    ) : SeederEntity[] {
+        return all.filter((seed) => {
+            if (!this.isMatch(seed, config)) {
                 return false;
             }
 
@@ -91,24 +122,38 @@ export class SeederExecutor {
                 return true;
             }
 
-            return !seed.effectiveTracking(options.seedTracking);
+            return !seed.effectiveTracking(config.seedTracking);
         });
+    }
 
-        if (pending.length === 0) {
-            if (queryRunner) {
-                await queryRunner.release();
-            }
-
-            return [];
+    protected isMatch(seed: SeederEntity, config: SeederConfig) : boolean {
+        if (!config.seedName) {
+            return true;
         }
 
-        this.dataSource.logger.logSchemaBuild(
-            `${existing.length} seeds are already present in the database.`,
-        );
-        this.dataSource.logger.logSchemaBuild(
-            `${all.length} seeds were found in the source code.`,
-        );
+        if (
+            seed.name === config.seedName ||
+            seed.fileName === config.seedName
+        ) {
+            return true;
+        }
 
+        if (!seed.filePath) {
+            return false;
+        }
+
+        if (seed.filePath === config.seedName) {
+            return true;
+        }
+
+        return resolveFilePath(config.seedName, this.options.root) === seed.filePath;
+    }
+
+    protected async runPending(
+        pending: SeederEntity[],
+        config: SeederConfig,
+        queryRunner?: QueryRunner,
+    ) : Promise<SeederEntity[]> {
         const factoryManager = new SeederFactoryManager({
             items: useSeederFactoryManager().items,
             dataSource: this.dataSource,
@@ -116,29 +161,23 @@ export class SeederExecutor {
 
         const executed : SeederEntity[] = [];
 
-        try {
-            for (const element of pending) {
-                const seeder = element.instance;
-                if (!seeder) {
-                    continue;
-                }
-
-                element.result = await seeder.run(this.dataSource, factoryManager);
-
-                if (queryRunner && element.effectiveTracking(options.seedTracking)) {
-                    await this.track(queryRunner, element, options.seedTableName);
-                }
-
-                this.dataSource.logger.logSchemaBuild(
-                    `Seed ${element.name} has been executed successfully.`,
-                );
-
-                executed.push(element);
+        for (const element of pending) {
+            const seeder = element.instance;
+            if (!seeder) {
+                continue;
             }
-        } finally {
-            if (queryRunner) {
-                await queryRunner.release();
+
+            element.result = await seeder.run(this.dataSource, factoryManager);
+
+            if (queryRunner && element.effectiveTracking(config.seedTracking)) {
+                await this.track(queryRunner, element, config.seedTableName);
             }
+
+            this.dataSource.logger.logSchemaBuild(
+                `Seed ${element.name} has been executed successfully.`,
+            );
+
+            executed.push(element);
         }
 
         return executed;
@@ -172,9 +211,6 @@ export class SeederExecutor {
         }));
     }
 
-    /**
-     * Gets all migrations that setup for this connection.
-     */
     protected async buildEntities(seeds?: SeederPrepareElement[]): Promise<SeederEntity[]> {
         if (!seeds) {
             return [];
@@ -335,34 +371,6 @@ export class SeederExecutor {
             this.schema,
             this.database,
         );
-    }
-
-    protected async buildOptions(input: SeederOptions = {}) : Promise<SeederConfig> {
-        const options = resolveSeederConfig(input, this.dataSourceOptions, useEnv());
-
-        if (!this.options.preserveFilePaths) {
-            let tsConfig : TSConfig;
-
-            if (isObject(this.options.tsconfig)) {
-                tsConfig = this.options.tsconfig;
-            } else {
-                tsConfig = await readTSConfig(
-                    resolveFilePath(this.options.tsconfig || 'tsconfig.json', this.options.root),
-                );
-            }
-
-            await adjustFilePaths(
-                options,
-                [
-                    'seeds',
-                    'seedName',
-                    'factories',
-                ],
-                tsConfig,
-            );
-        }
-
-        return options;
     }
 
     protected classNameToTimestamp(className: string) {

--- a/src/seeder/executor.ts
+++ b/src/seeder/executor.ts
@@ -6,9 +6,15 @@ import type { MongoQueryRunner } from 'typeorm/driver/mongodb/MongoQueryRunner';
 import { useEnv } from '../env';
 import { adjustFilePaths, readTSConfig, resolveFilePath } from '../utils';
 import type { TSConfig } from '../utils';
+import { resolveSeederConfig } from './config';
 import { SeederEntity } from './entity';
 import { SeederFactoryManager, prepareSeederFactories, useSeederFactoryManager } from './factory';
-import type { SeederExecutorOptions, SeederOptions, SeederPrepareElement } from './type';
+import type {
+    SeederConfig, 
+    SeederExecutorOptions, 
+    SeederOptions, 
+    SeederPrepareElement,
+} from './type';
 import { prepareSeederSeeds } from './utils';
 
 export class SeederExecutor {
@@ -354,41 +360,8 @@ export class SeederExecutor {
         );
     }
 
-    protected async buildOptions(input: SeederOptions = {}) {
-        const options : SeederOptions = {
-            ...input,
-            seeds: input.seeds || [],
-            factories: input.factories || [],
-            seedTracking: input.seedTracking ?? false,
-        };
-
-        if (!options.seeds || options.seeds.length === 0) {
-            options.seeds = this.dataSourceOptions.seeds;
-        }
-
-        if (!options.seeds || options.seeds.length === 0) {
-            options.seeds = useEnv('seeds');
-        }
-
-        if (!options.seeds || options.seeds.length === 0) {
-            options.seeds = ['src/database/seeds/**/*{.ts,.js}'];
-        }
-
-        if (!options.factories || options.factories.length === 0) {
-            options.factories = this.dataSourceOptions.factories;
-        }
-
-        if (!options.factories || options.factories.length === 0) {
-            options.factories = useEnv('factories');
-        }
-
-        if (!options.factories || options.factories.length === 0) {
-            options.factories = ['src/database/factories/**/*{.ts,.js}'];
-        }
-
-        if (typeof options.seedTracking === 'undefined') {
-            options.seedTracking = this.dataSourceOptions.seedTracking;
-        }
+    protected async buildOptions(input: SeederOptions = {}) : Promise<SeederConfig> {
+        const options = resolveSeederConfig(input, this.dataSourceOptions, useEnv());
 
         if (!this.options.preserveFilePaths) {
             let tsConfig : TSConfig;

--- a/src/seeder/executor.ts
+++ b/src/seeder/executor.ts
@@ -40,13 +40,13 @@ export class SeederExecutor {
         let queryRunner : QueryRunner | undefined;
         let existing : SeederEntity[] = [];
 
-        if (tracking) {
-            queryRunner = this.dataSource.createQueryRunner();
-            await this.createTableIfNotExist(queryRunner, config.seedTableName);
-            existing = await this.loadExisting(queryRunner, config.seedTableName);
-        }
-
         try {
+            if (tracking) {
+                queryRunner = this.dataSource.createQueryRunner();
+                await this.createTableIfNotExist(queryRunner, config.seedTableName);
+                existing = await this.loadExisting(queryRunner, config.seedTableName);
+            }
+
             const pending = this.filterPending(all, existing, config);
             if (pending.length === 0) {
                 return [];

--- a/src/seeder/executor.ts
+++ b/src/seeder/executor.ts
@@ -43,10 +43,8 @@ export class SeederExecutor {
         );
         const all = await this.buildEntities(seederElements);
 
-        let tracking = !!options.seedTracking;
-        if (!tracking) {
-            tracking = all.some((seed) => !!seed.trackExecution);
-        }
+        const tracking = options.seedTracking ||
+            all.some((seed) => seed.effectiveTracking(options.seedTracking));
 
         let queryRunner : QueryRunner | undefined;
         let existing : SeederEntity[] = [];
@@ -93,14 +91,7 @@ export class SeederExecutor {
                 return true;
             }
 
-            let seedTracking : boolean | undefined;
-            if (typeof seed.trackExecution !== 'undefined') {
-                seedTracking = seed.trackExecution;
-            } else {
-                seedTracking = options.seedTracking;
-            }
-
-            return !seedTracking;
+            return !seed.effectiveTracking(options.seedTracking);
         });
 
         if (pending.length === 0) {
@@ -134,14 +125,7 @@ export class SeederExecutor {
 
                 element.result = await seeder.run(this.dataSource, factoryManager);
 
-                let seedTracking : boolean | undefined;
-                if (typeof element.trackExecution !== 'undefined') {
-                    seedTracking = element.trackExecution;
-                } else {
-                    seedTracking = options.seedTracking;
-                }
-
-                if (queryRunner && seedTracking) {
+                if (queryRunner && element.effectiveTracking(options.seedTracking)) {
                     await this.track(queryRunner, element, options.seedTableName);
                 }
 
@@ -227,17 +211,7 @@ export class SeederExecutor {
 
         this.checkForDuplicates(entities);
 
-        // sort them by file name than by timestamp
-        return entities.sort((a, b) => {
-            if (
-                typeof a.fileName !== 'undefined' &&
-                typeof b.fileName !== 'undefined'
-            ) {
-                return a.fileName > b.fileName ? 1 : -1;
-            }
-
-            return a.timestamp - b.timestamp;
-        });
+        return entities.sort(SeederEntity.compare);
     }
 
     protected checkForDuplicates(entities: SeederEntity[]) {

--- a/src/seeder/index.ts
+++ b/src/seeder/index.ts
@@ -1,3 +1,4 @@
+export * from './config';
 export * from './entity';
 export * from './executor';
 export * from './factory';

--- a/src/seeder/type.ts
+++ b/src/seeder/type.ts
@@ -22,7 +22,6 @@ export type SeederOptions = {
     seedTracking?: boolean
 
     factories?: SeederFactoryItem[] | string[],
-    factoriesLoad?: boolean
 };
 
 /**

--- a/src/seeder/type.ts
+++ b/src/seeder/type.ts
@@ -25,6 +25,19 @@ export type SeederOptions = {
     factoriesLoad?: boolean
 };
 
+/**
+ * A fully resolved seeder configuration
+ * (explicit input ← data-source options ← environment ← built-in defaults).
+ */
+export type SeederConfig = {
+    seeds: SeederConstructor[] | string[],
+    seedName?: string,
+    seedTableName: string,
+    seedTracking: boolean,
+
+    factories: SeederFactoryItem[] | string[],
+};
+
 export type SeederExecutorOptions = {
     /**
      * Root directory of the project.

--- a/test/unit/seeder/config.spec.ts
+++ b/test/unit/seeder/config.spec.ts
@@ -1,0 +1,150 @@
+import type { DataSourceOptions } from 'typeorm';
+import { DataSource } from 'typeorm';
+import type { SeederOptions } from '../../../src';
+import { SeederExecutor, resetEnv } from '../../../src';
+
+const SEEDS_DEFAULT = ['src/database/seeds/**/*{.ts,.js}'];
+const FACTORIES_DEFAULT = ['src/database/factories/**/*{.ts,.js}'];
+
+function createExecutor(dataSourceOptions?: SeederOptions) {
+    const options : DataSourceOptions & SeederOptions = {
+        type: 'better-sqlite3',
+        database: ':memory:',
+        ...(dataSourceOptions || {}),
+    };
+
+    return new SeederExecutor(new DataSource(options), { preserveFilePaths: true });
+}
+
+async function buildOptions(executor: SeederExecutor, input: SeederOptions = {}) : Promise<SeederOptions> {
+    return (executor as any).buildOptions(input);
+}
+
+describe('src/seeder/config.ts', () => {
+    afterEach(() => {
+        delete process.env.DB_SEEDS;
+        delete process.env.DB_FACTORIES;
+
+        resetEnv();
+    });
+
+    describe('seeds', () => {
+        it('should prefer input over data-source options and env', async () => {
+            process.env.DB_SEEDS = 'env/seeds/*.ts';
+            const executor = createExecutor({ seeds: ['ds/seeds/*.ts'] });
+
+            const output = await buildOptions(executor, { seeds: ['input/seeds/*.ts'] });
+            expect(output.seeds).toEqual(['input/seeds/*.ts']);
+        });
+
+        it('should fall back to data-source options when input is empty', async () => {
+            process.env.DB_SEEDS = 'env/seeds/*.ts';
+            const executor = createExecutor({ seeds: ['ds/seeds/*.ts'] });
+
+            let output = await buildOptions(executor);
+            expect(output.seeds).toEqual(['ds/seeds/*.ts']);
+
+            output = await buildOptions(executor, { seeds: [] });
+            expect(output.seeds).toEqual(['ds/seeds/*.ts']);
+        });
+
+        it('should fall back to env when input and data-source options are empty', async () => {
+            process.env.DB_SEEDS = 'env/seeds/*.ts';
+            const executor = createExecutor();
+
+            const output = await buildOptions(executor);
+            expect(output.seeds).toEqual(['env/seeds/*.ts']);
+        });
+
+        it('should apply the built-in default last', async () => {
+            const executor = createExecutor();
+
+            const output = await buildOptions(executor);
+            expect(output.seeds).toEqual(SEEDS_DEFAULT);
+        });
+    });
+
+    describe('factories', () => {
+        it('should prefer input over data-source options and env', async () => {
+            process.env.DB_FACTORIES = 'env/factories/*.ts';
+            const executor = createExecutor({ factories: ['ds/factories/*.ts'] });
+
+            const output = await buildOptions(executor, { factories: ['input/factories/*.ts'] });
+            expect(output.factories).toEqual(['input/factories/*.ts']);
+        });
+
+        it('should fall back to data-source options when input is empty', async () => {
+            process.env.DB_FACTORIES = 'env/factories/*.ts';
+            const executor = createExecutor({ factories: ['ds/factories/*.ts'] });
+
+            const output = await buildOptions(executor);
+            expect(output.factories).toEqual(['ds/factories/*.ts']);
+        });
+
+        it('should fall back to env when input and data-source options are empty', async () => {
+            process.env.DB_FACTORIES = 'env/factories/*.ts';
+            const executor = createExecutor();
+
+            const output = await buildOptions(executor);
+            expect(output.factories).toEqual(['env/factories/*.ts']);
+        });
+
+        it('should apply the built-in default last', async () => {
+            const executor = createExecutor();
+
+            const output = await buildOptions(executor);
+            expect(output.factories).toEqual(FACTORIES_DEFAULT);
+        });
+    });
+
+    describe('seedName', () => {
+        it('should only be taken from input', async () => {
+            const executor = createExecutor({ seedName: 'FromDataSourceOptions' });
+
+            let output = await buildOptions(executor);
+            expect(output.seedName).toBeUndefined();
+
+            output = await buildOptions(executor, { seedName: 'FromInput' });
+            expect(output.seedName).toEqual('FromInput');
+        });
+    });
+
+    describe('seedTracking', () => {
+        it('should prefer input over data-source options', async () => {
+            const executor = createExecutor({ seedTracking: true });
+
+            const output = await buildOptions(executor, { seedTracking: false });
+            expect(output.seedTracking).toBe(false);
+        });
+
+        // characterization: the data-source options fallback is dead code —
+        // buildOptions defaults the input value to `false` before checking it.
+        it('should ignore data-source options when input is undefined (current behavior)', async () => {
+            const executor = createExecutor({ seedTracking: true });
+
+            const output = await buildOptions(executor);
+            expect(output.seedTracking).toBe(false);
+        });
+
+        it('should default to false', async () => {
+            const executor = createExecutor();
+
+            const output = await buildOptions(executor);
+            expect(output.seedTracking).toBe(false);
+        });
+    });
+
+    describe('seedTableName', () => {
+        // characterization: the executor resolves the table name in its constructor,
+        // exclusively from the data-source options — input is silently ignored.
+        it('should ignore input and only honor data-source options (current behavior)', async () => {
+            let executor = createExecutor({ seedTableName: 'custom_seed_table' });
+            expect((executor as any).tableName).toEqual('custom_seed_table');
+
+            executor = createExecutor();
+            const output = await buildOptions(executor, { seedTableName: 'custom_seed_table' });
+            expect(output.seedTableName).toEqual('custom_seed_table');
+            expect((executor as any).tableName).toEqual('seeds');
+        });
+    });
+});

--- a/test/unit/seeder/config.spec.ts
+++ b/test/unit/seeder/config.spec.ts
@@ -1,150 +1,155 @@
-import type { DataSourceOptions } from 'typeorm';
-import { DataSource } from 'typeorm';
-import type { SeederOptions } from '../../../src';
-import { SeederExecutor, resetEnv } from '../../../src';
+import { resolveSeederConfig } from '../../../src';
 
 const SEEDS_DEFAULT = ['src/database/seeds/**/*{.ts,.js}'];
 const FACTORIES_DEFAULT = ['src/database/factories/**/*{.ts,.js}'];
 
-function createExecutor(dataSourceOptions?: SeederOptions) {
-    const options : DataSourceOptions & SeederOptions = {
-        type: 'better-sqlite3',
-        database: ':memory:',
-        ...(dataSourceOptions || {}),
-    };
-
-    return new SeederExecutor(new DataSource(options), { preserveFilePaths: true });
-}
-
-async function buildOptions(executor: SeederExecutor, input: SeederOptions = {}) : Promise<SeederOptions> {
-    return (executor as any).buildOptions(input);
-}
-
 describe('src/seeder/config.ts', () => {
-    afterEach(() => {
-        delete process.env.DB_SEEDS;
-        delete process.env.DB_FACTORIES;
+    it('should apply the built-in defaults when nothing is provided', () => {
+        const config = resolveSeederConfig();
 
-        resetEnv();
+        expect(config).toEqual({
+            seeds: SEEDS_DEFAULT,
+            seedName: undefined,
+            seedTableName: 'seeds',
+            seedTracking: false,
+            factories: FACTORIES_DEFAULT,
+        });
     });
 
     describe('seeds', () => {
-        it('should prefer input over data-source options and env', async () => {
-            process.env.DB_SEEDS = 'env/seeds/*.ts';
-            const executor = createExecutor({ seeds: ['ds/seeds/*.ts'] });
+        it('should prefer input over data-source options and env', () => {
+            const config = resolveSeederConfig(
+                { seeds: ['input/seeds/*.ts'] },
+                { seeds: ['ds/seeds/*.ts'] },
+                { seeds: ['env/seeds/*.ts'], factories: [] },
+            );
 
-            const output = await buildOptions(executor, { seeds: ['input/seeds/*.ts'] });
-            expect(output.seeds).toEqual(['input/seeds/*.ts']);
+            expect(config.seeds).toEqual(['input/seeds/*.ts']);
         });
 
-        it('should fall back to data-source options when input is empty', async () => {
-            process.env.DB_SEEDS = 'env/seeds/*.ts';
-            const executor = createExecutor({ seeds: ['ds/seeds/*.ts'] });
+        it('should fall back to data-source options when input is empty', () => {
+            let config = resolveSeederConfig(
+                {},
+                { seeds: ['ds/seeds/*.ts'] },
+                { seeds: ['env/seeds/*.ts'], factories: [] },
+            );
+            expect(config.seeds).toEqual(['ds/seeds/*.ts']);
 
-            let output = await buildOptions(executor);
-            expect(output.seeds).toEqual(['ds/seeds/*.ts']);
-
-            output = await buildOptions(executor, { seeds: [] });
-            expect(output.seeds).toEqual(['ds/seeds/*.ts']);
+            config = resolveSeederConfig(
+                { seeds: [] },
+                { seeds: ['ds/seeds/*.ts'] },
+            );
+            expect(config.seeds).toEqual(['ds/seeds/*.ts']);
         });
 
-        it('should fall back to env when input and data-source options are empty', async () => {
-            process.env.DB_SEEDS = 'env/seeds/*.ts';
-            const executor = createExecutor();
+        it('should fall back to env when input and data-source options are empty', () => {
+            const config = resolveSeederConfig(
+                {},
+                {},
+                { seeds: ['env/seeds/*.ts'], factories: [] },
+            );
 
-            const output = await buildOptions(executor);
-            expect(output.seeds).toEqual(['env/seeds/*.ts']);
+            expect(config.seeds).toEqual(['env/seeds/*.ts']);
         });
 
-        it('should apply the built-in default last', async () => {
-            const executor = createExecutor();
+        it('should apply the built-in default last', () => {
+            const config = resolveSeederConfig({}, {}, { seeds: [], factories: [] });
 
-            const output = await buildOptions(executor);
-            expect(output.seeds).toEqual(SEEDS_DEFAULT);
+            expect(config.seeds).toEqual(SEEDS_DEFAULT);
         });
     });
 
     describe('factories', () => {
-        it('should prefer input over data-source options and env', async () => {
-            process.env.DB_FACTORIES = 'env/factories/*.ts';
-            const executor = createExecutor({ factories: ['ds/factories/*.ts'] });
+        it('should prefer input over data-source options and env', () => {
+            const config = resolveSeederConfig(
+                { factories: ['input/factories/*.ts'] },
+                { factories: ['ds/factories/*.ts'] },
+                { seeds: [], factories: ['env/factories/*.ts'] },
+            );
 
-            const output = await buildOptions(executor, { factories: ['input/factories/*.ts'] });
-            expect(output.factories).toEqual(['input/factories/*.ts']);
+            expect(config.factories).toEqual(['input/factories/*.ts']);
         });
 
-        it('should fall back to data-source options when input is empty', async () => {
-            process.env.DB_FACTORIES = 'env/factories/*.ts';
-            const executor = createExecutor({ factories: ['ds/factories/*.ts'] });
+        it('should fall back to data-source options when input is empty', () => {
+            const config = resolveSeederConfig(
+                { factories: [] },
+                { factories: ['ds/factories/*.ts'] },
+                { seeds: [], factories: ['env/factories/*.ts'] },
+            );
 
-            const output = await buildOptions(executor);
-            expect(output.factories).toEqual(['ds/factories/*.ts']);
+            expect(config.factories).toEqual(['ds/factories/*.ts']);
         });
 
-        it('should fall back to env when input and data-source options are empty', async () => {
-            process.env.DB_FACTORIES = 'env/factories/*.ts';
-            const executor = createExecutor();
+        it('should fall back to env when input and data-source options are empty', () => {
+            const config = resolveSeederConfig(
+                {},
+                {},
+                { seeds: [], factories: ['env/factories/*.ts'] },
+            );
 
-            const output = await buildOptions(executor);
-            expect(output.factories).toEqual(['env/factories/*.ts']);
+            expect(config.factories).toEqual(['env/factories/*.ts']);
         });
 
-        it('should apply the built-in default last', async () => {
-            const executor = createExecutor();
+        it('should apply the built-in default last', () => {
+            const config = resolveSeederConfig({}, {}, { seeds: [], factories: [] });
 
-            const output = await buildOptions(executor);
-            expect(output.factories).toEqual(FACTORIES_DEFAULT);
+            expect(config.factories).toEqual(FACTORIES_DEFAULT);
         });
     });
 
     describe('seedName', () => {
-        it('should only be taken from input', async () => {
-            const executor = createExecutor({ seedName: 'FromDataSourceOptions' });
+        it('should only be taken from input', () => {
+            let config = resolveSeederConfig({}, { seedName: 'FromDataSourceOptions' });
+            expect(config.seedName).toBeUndefined();
 
-            let output = await buildOptions(executor);
-            expect(output.seedName).toBeUndefined();
-
-            output = await buildOptions(executor, { seedName: 'FromInput' });
-            expect(output.seedName).toEqual('FromInput');
+            config = resolveSeederConfig(
+                { seedName: 'FromInput' },
+                { seedName: 'FromDataSourceOptions' },
+            );
+            expect(config.seedName).toEqual('FromInput');
         });
     });
 
     describe('seedTracking', () => {
-        it('should prefer input over data-source options', async () => {
-            const executor = createExecutor({ seedTracking: true });
+        it('should prefer input over data-source options', () => {
+            const config = resolveSeederConfig(
+                { seedTracking: false },
+                { seedTracking: true },
+            );
 
-            const output = await buildOptions(executor, { seedTracking: false });
-            expect(output.seedTracking).toBe(false);
+            expect(config.seedTracking).toBe(false);
         });
 
         // characterization: the data-source options fallback is dead code —
-        // buildOptions defaults the input value to `false` before checking it.
-        it('should ignore data-source options when input is undefined (current behavior)', async () => {
-            const executor = createExecutor({ seedTracking: true });
+        // the input value is defaulted to `false` before it is checked.
+        it('should ignore data-source options when input is undefined (current behavior)', () => {
+            const config = resolveSeederConfig({}, { seedTracking: true });
 
-            const output = await buildOptions(executor);
-            expect(output.seedTracking).toBe(false);
+            expect(config.seedTracking).toBe(false);
         });
 
-        it('should default to false', async () => {
-            const executor = createExecutor();
+        it('should default to false', () => {
+            const config = resolveSeederConfig();
 
-            const output = await buildOptions(executor);
-            expect(output.seedTracking).toBe(false);
+            expect(config.seedTracking).toBe(false);
         });
     });
 
     describe('seedTableName', () => {
-        // characterization: the executor resolves the table name in its constructor,
-        // exclusively from the data-source options — input is silently ignored.
-        it('should ignore input and only honor data-source options (current behavior)', async () => {
-            let executor = createExecutor({ seedTableName: 'custom_seed_table' });
-            expect((executor as any).tableName).toEqual('custom_seed_table');
+        // characterization: the table name is resolved exclusively from the
+        // data-source options — input is silently ignored.
+        it('should ignore input and only honor data-source options (current behavior)', () => {
+            let config = resolveSeederConfig({}, { seedTableName: 'custom_seed_table' });
+            expect(config.seedTableName).toEqual('custom_seed_table');
 
-            executor = createExecutor();
-            const output = await buildOptions(executor, { seedTableName: 'custom_seed_table' });
-            expect(output.seedTableName).toEqual('custom_seed_table');
-            expect((executor as any).tableName).toEqual('seeds');
+            config = resolveSeederConfig({ seedTableName: 'custom_seed_table' }, {});
+            expect(config.seedTableName).toEqual('seeds');
+        });
+
+        it('should default to "seeds"', () => {
+            const config = resolveSeederConfig();
+
+            expect(config.seedTableName).toEqual('seeds');
         });
     });
 });

--- a/test/unit/seeder/config.spec.ts
+++ b/test/unit/seeder/config.spec.ts
@@ -120,12 +120,10 @@ describe('src/seeder/config.ts', () => {
             expect(config.seedTracking).toBe(false);
         });
 
-        // characterization: the data-source options fallback is dead code —
-        // the input value is defaulted to `false` before it is checked.
-        it('should ignore data-source options when input is undefined (current behavior)', () => {
+        it('should fall back to data-source options when input is undefined', () => {
             const config = resolveSeederConfig({}, { seedTracking: true });
 
-            expect(config.seedTracking).toBe(false);
+            expect(config.seedTracking).toBe(true);
         });
 
         it('should default to false', () => {

--- a/test/unit/seeder/config.spec.ts
+++ b/test/unit/seeder/config.spec.ts
@@ -136,14 +136,19 @@ describe('src/seeder/config.ts', () => {
     });
 
     describe('seedTableName', () => {
-        // characterization: the table name is resolved exclusively from the
-        // data-source options — input is silently ignored.
-        it('should ignore input and only honor data-source options (current behavior)', () => {
-            let config = resolveSeederConfig({}, { seedTableName: 'custom_seed_table' });
-            expect(config.seedTableName).toEqual('custom_seed_table');
+        it('should prefer input over data-source options', () => {
+            const config = resolveSeederConfig(
+                { seedTableName: 'input_seed_table' },
+                { seedTableName: 'ds_seed_table' },
+            );
 
-            config = resolveSeederConfig({ seedTableName: 'custom_seed_table' }, {});
-            expect(config.seedTableName).toEqual('seeds');
+            expect(config.seedTableName).toEqual('input_seed_table');
+        });
+
+        it('should fall back to data-source options', () => {
+            const config = resolveSeederConfig({}, { seedTableName: 'ds_seed_table' });
+
+            expect(config.seedTableName).toEqual('ds_seed_table');
         });
 
         it('should default to "seeds"', () => {

--- a/test/unit/seeder/entity.spec.ts
+++ b/test/unit/seeder/entity.spec.ts
@@ -64,6 +64,15 @@ describe('src/seeder/entity.ts', () => {
             expect(SeederEntity.compare(b, a)).toBeGreaterThan(0);
         });
 
+        it('should fall back to timestamp for equal file names', () => {
+            const a = createEntity({ fileName: 'seed.ts', timestamp: 1 });
+            const b = createEntity({ fileName: 'seed.ts', timestamp: 2 });
+
+            expect(SeederEntity.compare(a, b)).toBeLessThan(0);
+            expect(SeederEntity.compare(b, a)).toBeGreaterThan(0);
+            expect(SeederEntity.compare(a, a)).toEqual(0);
+        });
+
         it('should order by timestamp when a file name is missing', () => {
             const a = createEntity({ timestamp: 1 });
             const b = createEntity({ fileName: 'b-seed.ts', timestamp: 2 });

--- a/test/unit/seeder/entity.spec.ts
+++ b/test/unit/seeder/entity.spec.ts
@@ -1,0 +1,89 @@
+/* eslint-disable max-classes-per-file */
+import type { Seeder } from '../../../src';
+import { SeederEntity } from '../../../src';
+
+class TrackedSeeder implements Seeder {
+    track = true;
+
+    public async run() : Promise<unknown> {
+        return undefined;
+    }
+}
+
+class UntrackedSeeder implements Seeder {
+    track = false;
+
+    public async run() : Promise<unknown> {
+        return undefined;
+    }
+}
+
+class DefaultSeeder implements Seeder {
+    public async run() : Promise<unknown> {
+        return undefined;
+    }
+}
+
+function createEntity(ctx: {
+    constructor?: new () => Seeder,
+    timestamp?: number,
+    fileName?: string
+}) : SeederEntity {
+    return new SeederEntity({
+        timestamp: ctx.timestamp ?? 0,
+        name: ctx.constructor ? ctx.constructor.name : 'Anonymous',
+        constructor: ctx.constructor,
+        fileName: ctx.fileName,
+    });
+}
+
+describe('src/seeder/entity.ts', () => {
+    describe('effectiveTracking', () => {
+        it('should prefer the per-seed track property over the executor-level default', () => {
+            expect(createEntity({ constructor: TrackedSeeder }).effectiveTracking(false)).toBe(true);
+            expect(createEntity({ constructor: UntrackedSeeder }).effectiveTracking(true)).toBe(false);
+        });
+
+        it('should fall back to the executor-level default', () => {
+            expect(createEntity({ constructor: DefaultSeeder }).effectiveTracking(true)).toBe(true);
+            expect(createEntity({ constructor: DefaultSeeder }).effectiveTracking(false)).toBe(false);
+        });
+
+        it('should fall back to the executor-level default without an instance', () => {
+            expect(createEntity({}).effectiveTracking(true)).toBe(true);
+            expect(createEntity({}).effectiveTracking(false)).toBe(false);
+        });
+    });
+
+    describe('compare', () => {
+        it('should order by file name when both entities are file-backed', () => {
+            const a = createEntity({ fileName: 'a-seed.ts', timestamp: 2 });
+            const b = createEntity({ fileName: 'b-seed.ts', timestamp: 1 });
+
+            expect(SeederEntity.compare(a, b)).toBeLessThan(0);
+            expect(SeederEntity.compare(b, a)).toBeGreaterThan(0);
+        });
+
+        it('should order by timestamp when a file name is missing', () => {
+            const a = createEntity({ timestamp: 1 });
+            const b = createEntity({ fileName: 'b-seed.ts', timestamp: 2 });
+
+            expect(SeederEntity.compare(a, b)).toBeLessThan(0);
+            expect(SeederEntity.compare(b, a)).toBeGreaterThan(0);
+            expect(SeederEntity.compare(a, a)).toEqual(0);
+        });
+
+        it('should sort a mixed list deterministically', () => {
+            const entities = [
+                createEntity({ fileName: 'b-seed.ts', timestamp: 0 }),
+                createEntity({ fileName: 'a-seed.ts', timestamp: 3 }),
+            ];
+
+            const sorted = [...entities].sort(SeederEntity.compare);
+            expect(sorted.map((entity) => entity.fileName)).toEqual([
+                'a-seed.ts',
+                'b-seed.ts',
+            ]);
+        });
+    });
+});

--- a/test/unit/seeder/executor.spec.ts
+++ b/test/unit/seeder/executor.spec.ts
@@ -46,9 +46,7 @@ describe('src/seeder/executor.ts', () => {
         expect(rows[0].name).toEqual('UserSeeder');
     });
 
-    // characterization: seedTracking from the data-source options is silently ignored —
-    // the seed re-runs on every invocation.
-    it('should ignore seedTracking from the data-source options (current behavior)', async () => {
+    it('should honor seedTracking from the data-source options', async () => {
         Object.assign(dataSource.options, { seedTracking: true });
 
         const executor = new SeederExecutor(dataSource);
@@ -57,7 +55,7 @@ describe('src/seeder/executor.ts', () => {
         expect(output.length).toEqual(1);
 
         output = await executor.execute({ seeds: [UntrackedSeeder] });
-        expect(output.length).toEqual(1);
+        expect(output.length).toEqual(0);
     });
 
     it('should honor seedTracking from the options input', async () => {

--- a/test/unit/seeder/executor.spec.ts
+++ b/test/unit/seeder/executor.spec.ts
@@ -1,0 +1,76 @@
+import type { DataSource } from 'typeorm';
+import type { Seeder } from '../../../src';
+import { SeederExecutor } from '../../../src';
+import { User } from '../../data/entity/user';
+import { destroyTestFsDataSource, setupFsDataSource } from '../../data/typeorm/utils';
+import '../../data/factory/user';
+import UserSeeder from '../../data/seed/user';
+
+class UntrackedSeeder implements Seeder {
+    public async run() : Promise<unknown> {
+        return 'executed';
+    }
+}
+
+async function findTable(dataSource: DataSource, name: string) : Promise<unknown[]> {
+    return dataSource.query(
+        'SELECT name FROM sqlite_master WHERE type = \'table\' AND name = ?',
+        [name],
+    );
+}
+
+describe('src/seeder/executor.ts', () => {
+    let dataSource : DataSource;
+
+    beforeEach(async () => {
+        dataSource = await setupFsDataSource('seeder-executor');
+    });
+
+    afterEach(async () => {
+        await destroyTestFsDataSource(dataSource);
+    });
+
+    // characterization: seedTableName from the options input is silently ignored —
+    // tracking rows land in the default `seeds` table.
+    it('should ignore a custom seedTableName from the options input (current behavior)', async () => {
+        const executor = new SeederExecutor(dataSource);
+        const output = await executor.execute({
+            seeds: [UserSeeder],
+            seedTableName: 'custom_seed_table',
+        });
+        expect(output.length).toEqual(1);
+
+        expect(await findTable(dataSource, 'custom_seed_table')).toHaveLength(0);
+        expect(await findTable(dataSource, 'seeds')).toHaveLength(1);
+    });
+
+    // characterization: seedTracking from the data-source options is silently ignored —
+    // the seed re-runs on every invocation.
+    it('should ignore seedTracking from the data-source options (current behavior)', async () => {
+        Object.assign(dataSource.options, { seedTracking: true });
+
+        const executor = new SeederExecutor(dataSource);
+
+        let output = await executor.execute({ seeds: [UntrackedSeeder] });
+        expect(output.length).toEqual(1);
+
+        output = await executor.execute({ seeds: [UntrackedSeeder] });
+        expect(output.length).toEqual(1);
+    });
+
+    it('should honor seedTracking from the options input', async () => {
+        const executor = new SeederExecutor(dataSource);
+
+        let output = await executor.execute({
+            seeds: [UntrackedSeeder],
+            seedTracking: true,
+        });
+        expect(output.length).toEqual(1);
+
+        output = await executor.execute({
+            seeds: [UntrackedSeeder],
+            seedTracking: true,
+        });
+        expect(output.length).toEqual(0);
+    });
+});

--- a/test/unit/seeder/executor.spec.ts
+++ b/test/unit/seeder/executor.spec.ts
@@ -30,9 +30,7 @@ describe('src/seeder/executor.ts', () => {
         await destroyTestFsDataSource(dataSource);
     });
 
-    // characterization: seedTableName from the options input is silently ignored —
-    // tracking rows land in the default `seeds` table.
-    it('should ignore a custom seedTableName from the options input (current behavior)', async () => {
+    it('should honor a custom seedTableName from the options input', async () => {
         const executor = new SeederExecutor(dataSource);
         const output = await executor.execute({
             seeds: [UserSeeder],
@@ -40,8 +38,12 @@ describe('src/seeder/executor.ts', () => {
         });
         expect(output.length).toEqual(1);
 
-        expect(await findTable(dataSource, 'custom_seed_table')).toHaveLength(0);
-        expect(await findTable(dataSource, 'seeds')).toHaveLength(1);
+        expect(await findTable(dataSource, 'custom_seed_table')).toHaveLength(1);
+        expect(await findTable(dataSource, 'seeds')).toHaveLength(0);
+
+        const rows = await dataSource.query('SELECT name FROM custom_seed_table');
+        expect(rows).toHaveLength(1);
+        expect(rows[0].name).toEqual('UserSeeder');
     });
 
     // characterization: seedTracking from the data-source options is silently ignored —

--- a/test/unit/seeder/executor.spec.ts
+++ b/test/unit/seeder/executor.spec.ts
@@ -1,14 +1,20 @@
+/* eslint-disable max-classes-per-file */
 import type { DataSource } from 'typeorm';
 import type { Seeder } from '../../../src';
-import { SeederExecutor } from '../../../src';
-import { User } from '../../data/entity/user';
+import { SeederExecutor, runSeeder } from '../../../src';
 import { destroyTestFsDataSource, setupFsDataSource } from '../../data/typeorm/utils';
-import '../../data/factory/user';
+import userFactoryItem from '../../data/factory/user';
 import UserSeeder from '../../data/seed/user';
 
 class UntrackedSeeder implements Seeder {
     public async run() : Promise<unknown> {
         return 'executed';
+    }
+}
+
+class TimestampSeeder1700000000000 implements Seeder {
+    public async run() : Promise<unknown> {
+        return undefined;
     }
 }
 
@@ -69,6 +75,51 @@ describe('src/seeder/executor.ts', () => {
 
         output = await executor.execute({
             seeds: [UntrackedSeeder],
+            seedTracking: true,
+        });
+        expect(output.length).toEqual(0);
+    });
+
+    it('should run a single seed selected by class name', async () => {
+        const entity = await runSeeder(dataSource, 'UserSeeder');
+
+        expect(entity).toBeDefined();
+        expect(entity?.name).toEqual('UserSeeder');
+    });
+
+    it('should run a single seed selected by file name', async () => {
+        const executor = new SeederExecutor(dataSource, { preserveFilePaths: true });
+        const output = await executor.execute({
+            seeds: ['test/data/seed/{role,user}.ts'],
+            seedName: 'user.ts',
+        });
+
+        expect(output.length).toEqual(1);
+        expect(output[0].name).toEqual('UserSeeder');
+    });
+
+    it('should register factories provided as items', async () => {
+        const executor = new SeederExecutor(dataSource);
+        const output = await executor.execute({
+            seeds: [UserSeeder],
+            factories: [userFactoryItem],
+        });
+
+        expect(output.length).toEqual(1);
+    });
+
+    it('should derive the tracking timestamp from the class name', async () => {
+        const executor = new SeederExecutor(dataSource);
+
+        let output = await executor.execute({
+            seeds: [TimestampSeeder1700000000000],
+            seedTracking: true,
+        });
+        expect(output.length).toEqual(1);
+        expect(output[0].timestamp).toEqual(1700000000000);
+
+        output = await executor.execute({
+            seeds: [TimestampSeeder1700000000000],
             seedTracking: true,
         });
         expect(output.length).toEqual(0);

--- a/test/unit/seeder/factory.spec.ts
+++ b/test/unit/seeder/factory.spec.ts
@@ -75,6 +75,7 @@ describe('src/seeder/factory/index.ts', () => {
             expect(saved.role.id).toBeDefined();
         } finally {
             setSeederFactory(User, userFactoryItem.factoryFn);
+            delete useSeederFactoryManager().items[Role.name];
         }
     });
 

--- a/test/unit/seeder/factory.spec.ts
+++ b/test/unit/seeder/factory.spec.ts
@@ -8,7 +8,7 @@ import {
 import { Role } from '../../data/entity/role';
 import { User } from '../../data/entity/user';
 import { destroyTestFsDataSource, setupFsDataSource } from '../../data/typeorm/utils';
-import '../../data/factory/user';
+import userFactoryItem from '../../data/factory/user';
 
 describe('src/seeder/factory/index.ts', () => {
     let dataSource : DataSource;
@@ -44,6 +44,38 @@ describe('src/seeder/factory/index.ts', () => {
         factory.setLocale('de');
         user = await factory.save();
         expect(user).toBeDefined();
+    });
+
+    it('should resolve nested factories and thenable properties', async () => {
+        setSeederFactory(Role, () => {
+            const role = new Role();
+            role.name = 'nested';
+
+            return role;
+        });
+
+        setSeederFactory(User, (faker) => {
+            const user = new User();
+            user.firstName = faker.person.firstName();
+            user.lastName = faker.person.lastName();
+            user.email = { then: (resolve: (value: string) => void) => resolve('nested@example.com') } as unknown as string;
+            user.role = useSeederFactory(Role) as unknown as Role;
+
+            return user;
+        });
+
+        try {
+            const made = await useSeederFactory(User).make();
+            expect(made.role).toBeInstanceOf(Role);
+            expect(made.email).toEqual('nested@example.com');
+
+            const saved = await useSeederFactory(User).save();
+            expect(saved.id).toBeDefined();
+            expect(saved.role).toBeInstanceOf(Role);
+            expect(saved.role.id).toBeDefined();
+        } finally {
+            setSeederFactory(User, userFactoryItem.factoryFn);
+        }
     });
 
     it('should reset the factory manager', () => {

--- a/test/unit/seeder/utils/file-path.spec.ts
+++ b/test/unit/seeder/utils/file-path.spec.ts
@@ -1,7 +1,27 @@
 import path from 'node:path';
-import { buildFilePathname } from '../../../../src';
+import { buildFilePathname, resolveFilePaths } from '../../../../src';
 
 describe('src/seeder/utils/file-path.ts', () => {
+    describe('resolveFilePaths', () => {
+        it('should keep absolute paths untouched', () => {
+            const input = path.join(path.sep, 'path', 'to', 'file.ts');
+
+            expect(resolveFilePaths([input])).toEqual([input]);
+        });
+
+        it('should resolve relative paths against the root', () => {
+            expect(resolveFilePaths(['file.ts'], path.join(path.sep, 'root'))).toEqual([
+                path.join(path.sep, 'root', 'file.ts'),
+            ]);
+        });
+
+        it('should resolve relative paths against the working directory', () => {
+            expect(resolveFilePaths(['file.ts'])).toEqual([
+                path.resolve(process.cwd(), 'file.ts'),
+            ]);
+        });
+    });
+
     describe('buildFilePathname', () => {
         it('should build file path name', () => {
             const files = [

--- a/test/unit/seeder/utils/template.spec.ts
+++ b/test/unit/seeder/utils/template.spec.ts
@@ -1,0 +1,12 @@
+import { buildSeederFileTemplate } from '../../../../src';
+
+describe('src/seeder/utils/template.ts', () => {
+    describe('buildSeederFileTemplate', () => {
+        it('should build a seeder class template', () => {
+            const template = buildSeederFileTemplate('foo-bar', 1700000000000);
+
+            expect(template).toContain('export class FooBar1700000000000 implements Seeder');
+            expect(template).toContain('track = false;');
+        });
+    });
+});

--- a/test/vitest.config.ts
+++ b/test/vitest.config.ts
@@ -37,7 +37,6 @@ export default defineConfig({
                 'src/env/utils.ts',
                 'src/errors/*.{ts,js}',
                 'src/utils/**/*.{ts,js}',
-                'src/seeder/**/*.{ts,js}',
             ],
             thresholds: {
                 branches: 80,


### PR DESCRIPTION
## RFC

Implements the [seeder-config-resolver plan] — the "combine input + dataSource.options + env + defaults" concern for the seeder domain now lives in **one pure function**, and `SeederExecutor.execute` reads as a short pipeline instead of a 130-line method with the tracking decision written out three times.

### Defects fixed (public API contract)

1. **`seedTableName` from the options input was silently ignored** — it was read only in the constructor, only from `dataSource.options`, so `runSeeders(ds, { seedTableName: 'x' })` did nothing despite the field being on the public `SeederOptions`. The table name is now resolved per execution: input ← data-source options ← `'seeds'`.
2. **`seedTracking` from the data-source options was silently ignored** — `buildOptions` defaulted the input value to `false` *before* checking the data-source options, leaving that fallback branch dead. Precedence is now: input ← data-source options ← `false`.
3. **`factoriesLoad` removed (`feat!`)** — the flag existed only on the `SeederOptions` type; nothing ever read it. Removed instead of implemented (BREAKING CHANGE footer on the commit).

### Design

- `src/seeder/config.ts` — `resolveSeederConfig(input, dataSourceOptions, env) : SeederConfig`. Pure: env is a parameter, no `useEnv()` buried inside; returns a fully resolved config (no optional seeds/factories/tracking fields). Exported from the public barrel so the CLI context work (plan 003) can consume it later.
- `SeederExecutor.execute` decomposed into named stages: `resolveConfig` → `prepareSeederFactories` → `loadEntities` → tracking-store setup → `filterPending` → `runPending`. The query runner is released in a single `try/finally`.
- The tripled tracking if/else now lives once in `SeederEntity.effectiveTracking(fallback)`; the ordering comparator once in the static `SeederEntity.compare`.
- Protected surface changed (beta window): `buildOptions` → `resolveConfig`, the constructor no longer pre-computes a `tableName` field, and the table-name-dependent helpers take the resolved name as a parameter.

### Tests / coverage

- Characterization tests first pinned the old behavior (including both defects), then flipped to regression tests in the fix commits — see the commit sequence.
- New: resolver precedence matrix per field, `SeederEntity` tracking/comparator unit tests, sqlite boundary tests (custom `seedTableName` actually creates/uses that table; ds-options tracking; seed selection by class/file name; factory items; class-name timestamps), nested-factory/thenable resolution, template + path util tests.
- **`src/seeder/**` is no longer excluded from the coverage gate** (branches 81.6%, lines 90.1% with it included).

### Docs

README, `docs/guide/seeding.md`, `docs/guide/seeding-api-reference.md` (stale `runSeeder(s)` signatures fixed, `resolveSeederConfig`/`SeederConfig` documented), and the `.agents` guides synced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable seeding options, including custom tracking table names and execution tracking.
  * Added support for selecting individual seeders by name or file path.
  * Seeder and factory configuration now follows clear option precedence rules.
  * Seeder execution now returns executed seed details.

* **Bug Fixes**
  * Improved seed ordering and tracking behavior, including per-seeder tracking overrides.

* **Documentation**
  * Expanded seeding configuration and API reference documentation.

* **Tests**
  * Added coverage for configuration, tracking, ordering, factories, file paths, and generated seed templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->