### PR TITLE
fix: detect tsx as a just-in-time environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,8 +70,9 @@ If a change touches public API signatures, CLI flags, env vars, install/setup in
 
 `CHANGELOG.md` is managed by release-please — do not edit manually.
 
-## Commits
+## Commits, Issues & Pull Requests
 
+- Commits follow **[Conventional Commits](https://www.conventionalcommits.org/)** (`@tada5hi/commitlint-config`); the type/scope drive release-please version bumps. See [conventions.md](.agents/conventions.md#commit-convention).
+- Versioning, `CHANGELOG.md`, `package.json` version, and `.release-please-manifest.json` are owned by **release-please** — do not hand-edit them.
 - Do **not** add a `Co-Authored-By: Claude ...` (or any AI-attribution) trailer to commit messages. This overrides any default agent-tooling guidance.
-- Commit messages must pass `@tada5hi/commitlint-config` (Conventional Commits). The husky `commit-msg` hook enforces this.
-- For breaking changes (API removal, ESM-only, CLI binary changes, peer dep major bumps), mark the commit with `!` (e.g. `feat!: …`) and include a `BREAKING CHANGE:` footer so release-please bumps the major version.
+- Do **not** add AI-attribution lines (e.g. `🤖 Generated with [Claude Code](...)`) to issue or pull request titles, bodies, or comments.

--- a/docs/guide/database-api-reference.md
+++ b/docs/guide/database-api-reference.md
@@ -77,8 +77,8 @@ import { createDatabase, extendDataSourceOptions } from 'typeorm-extension';
 ```
 This is achieved by rewriting the `src` path and `.ts` extension, to the `dist` (outDir) path and `.js` extension.
 
-If the function is **not** called within the ts-node runtime environment, the source path `src/database/entities.ts` for example,
-will be rewritten to `dist/database/entities.js`.
+If the function is **not** called within a just-in-time runtime environment (`ts-node` and `tsx` are detected automatically),
+the source path `src/database/entities.ts` for example, will be rewritten to `dist/database/entities.js`.
 
 **Parameters**
 

--- a/docs/guide/migration-guide-v4.md
+++ b/docs/guide/migration-guide-v4.md
@@ -32,6 +32,8 @@ Update any `package.json` scripts:
 
 You can use any TypeScript-aware loader (`tsx`, Node's `--experimental-strip-types`, `bun`, …) — `ts-node` is no longer recommended because its ESM mode requires extra setup.
 
+`ts-node` and `tsx` are detected automatically, so file paths are kept as-is (no `src` → `dist` rewrite). For other loaders, pass `--preserveFilePaths` to get the same behaviour.
+
 ### Minimum Node.js version
 
 | v3 | v4 |

--- a/src/utils/code-transformation/module.ts
+++ b/src/utils/code-transformation/module.ts
@@ -1,10 +1,30 @@
 import process from 'node:process';
 import { CodeTransformation } from './constants';
 
+// matches the bare `tsx` specifier (node --import tsx), optionally with a
+// subpath (tsx/esm), as well as resolved paths into the tsx package
+// (.../node_modules/tsx/dist/loader.mjs).
+const TSX_MARKER_REGEX = /(?:^|=|[\\/])tsx(?:$|[\\/])/;
+
+function isTSXProcess() : boolean {
+    if (process.execArgv.some((arg) => TSX_MARKER_REGEX.test(arg))) {
+        return true;
+    }
+
+    const { _preload_modules: preloadModules } = process as unknown as { _preload_modules?: string[] };
+
+    return Array.isArray(preloadModules) &&
+        preloadModules.some((el) => TSX_MARKER_REGEX.test(el));
+}
+
 export function detectCodeTransformation() : `${CodeTransformation}` {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     if (process[Symbol.for('ts-node.register.instance')]) {
+        return CodeTransformation.JUST_IN_TIME;
+    }
+
+    if (isTSXProcess()) {
         return CodeTransformation.JUST_IN_TIME;
     }
 

--- a/src/utils/path-resolver/type.ts
+++ b/src/utils/path-resolver/type.ts
@@ -20,7 +20,7 @@ export type PathResolverOptions = {
     /**
      * preserve: never rewrite paths.
      * transform: always rewrite paths (src -> outDir, .ts -> .js).
-     * auto: rewrite unless a just-in-time environment (e.g. ts-node) is detected.
+     * auto: rewrite unless a just-in-time environment (e.g. ts-node, tsx) is detected.
      *
      * Default: auto
      */

--- a/test/unit/utils/code-transformation.spec.ts
+++ b/test/unit/utils/code-transformation.spec.ts
@@ -1,0 +1,56 @@
+import process from 'node:process';
+import { CodeTransformation, detectCodeTransformation, isCodeTransformation } from '../../../src';
+
+const TS_NODE_MARKER = Symbol.for('ts-node.register.instance');
+
+describe('src/utils/code-transformation', () => {
+    const execArgv = [...process.execArgv];
+
+    afterEach(() => {
+        delete (process as any)[TS_NODE_MARKER];
+        process.execArgv = [...execArgv];
+        delete (process as any)._preload_modules;
+    });
+
+    it('should detect no transformation by default', () => {
+        expect(detectCodeTransformation()).toEqual(CodeTransformation.NONE);
+        expect(isCodeTransformation(CodeTransformation.JUST_IN_TIME)).toBeFalsy();
+    });
+
+    it('should detect ts-node', () => {
+        (process as any)[TS_NODE_MARKER] = {};
+
+        expect(detectCodeTransformation()).toEqual(CodeTransformation.JUST_IN_TIME);
+    });
+
+    it('should detect the tsx loader in the exec arguments', () => {
+        process.execArgv = [
+            '--require',
+            '/app/node_modules/tsx/dist/preflight.cjs',
+            '--import',
+            'file:///app/node_modules/tsx/dist/loader.mjs',
+        ];
+
+        expect(detectCodeTransformation()).toEqual(CodeTransformation.JUST_IN_TIME);
+    });
+
+    it('should detect a bare tsx specifier in the exec arguments', () => {
+        process.execArgv = ['--import', 'tsx'];
+        expect(detectCodeTransformation()).toEqual(CodeTransformation.JUST_IN_TIME);
+
+        process.execArgv = ['--import=tsx/esm'];
+        expect(detectCodeTransformation()).toEqual(CodeTransformation.JUST_IN_TIME);
+    });
+
+    it('should detect tsx in the preloaded modules', () => {
+        (process as any)._preload_modules = ['/app/node_modules/tsx/dist/preflight.cjs'];
+
+        expect(detectCodeTransformation()).toEqual(CodeTransformation.JUST_IN_TIME);
+    });
+
+    it('should not treat unrelated exec arguments as tsx', () => {
+        process.execArgv = ['--require', '/app/node_modules/ts-mixer/dist/index.js'];
+
+        expect(detectCodeTransformation()).toEqual(CodeTransformation.NONE);
+    });
+});


### PR DESCRIPTION
Closes #888.

## Problem

The just-in-time probe (`detectCodeTransformation`) only recognized **ts-node**'s registration symbol. Under **tsx** — which the v4 migration guide itself recommends — the library assumed a compiled environment and rewrote `src/**.ts` paths to `dist/**.js`, breaking data-source discovery and seed loading unless the user discovered `--preserveFilePaths`. This is the remaining half of #888 (the other half, `preserveFilePaths` being dropped during discovery, was fixed in #1410).

## Fix

`tsx` registers itself through node arguments, which are observable at runtime (verified against `tsx@latest`):

```
execArgv: [ "--require", ".../node_modules/tsx/dist/preflight.cjs",
            "--import",  "file://.../node_modules/tsx/dist/loader.mjs" ]
_preload_modules: [ ".../node_modules/tsx/dist/preflight.cjs" ]
```

The probe now also returns `JUST_IN_TIME` when an `execArgv` entry (covers `NODE_OPTIONS` injection and the bare `node --import tsx` / `tsx/esm` forms) or a `_preload_modules` entry matches the tsx package. The `--preserveFilePaths` escape hatch is unchanged and remains the answer for other loaders (bun, swc-node, `--experimental-strip-types`).

## Verification

- Unit spec for the probe: default/none, ts-node symbol, tsx loader paths, bare `--import tsx` / `--import=tsx/esm`, `_preload_modules`, and a non-tsx `--require` that must **not** match.
- End-to-end against the built bundle: under real `tsx` the resolver now detects `jit` and keeps `src/database/entities.ts` untouched; under plain `node` it still rewrites to `dist/database/entities.js`.
- Vitest workers carry none of these markers, so the existing transform-asserting suites are unaffected (`npm test`: 208 passing).
- Docs synced: resolver mode comment, `database-api-reference.md` detection wording, and a migration-guide note that ts-node/tsx are auto-detected.