### PR TITLE
chore: use release-please prerelease versioning strategy

### DIFF
--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -107,9 +107,9 @@ The CLI bundle's `cliRewriteExternal` plugin rewrites cross-domain imports back 
 Settings (`release-please-config.json`):
 
 - `release-type: node`
-- `include-v-in-tag: true` — tags look like `v3.10.0`
-- `prerelease: true`, `prerelease-type: alpha` — pre-1.0 / pre-release semantics apply.
-- `bump-minor-pre-major: true`, `bump-patch-for-minor-pre-major: true` — `feat:` ⇒ minor, `fix:` ⇒ patch (no major bumps without explicit `BREAKING CHANGE`).
+- `include-component-in-tag: false` — tags look like `v4.0.0-beta.0`
+- `versioning: prerelease` + `prerelease: true`, `prerelease-type: beta` — while the current version is a prerelease of `X.0.0`, further commits (including breaking changes) bump only the prerelease number (`4.0.0-beta.0` → `4.0.0-beta.1`) instead of the major. Cutting the stable `4.0.0` requires an explicit `Release-As: 4.0.0` commit footer (or flipping `prerelease` off).
+- `bump-minor-pre-major: true`, `bump-patch-for-minor-pre-major: true` — pre-1.0 only: `feat:` ⇒ minor, `fix:` ⇒ patch.
 
 The manifest at `.release-please-manifest.json` tracks the current version.
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,7 @@
 {
     "release-type": "node",
     "include-component-in-tag": false,
+    "versioning": "prerelease",
     "prerelease": true,
     "prerelease-type": "beta",
     "bump-minor-pre-major": true,


### PR DESCRIPTION
## Problem

The open release PR (#1405) proposes `5.0.0-beta.0`. The breaking-change commits landed since `v4.0.0-beta.0` (#1401, #1404, #1406, #1409, #1413) make release-please's **default** versioning strategy bump the major — even though `4.0.0` was never released as stable. The next version should stay on the 4.0.0 line: `4.0.0-beta.1`.

## Fix

Set `"versioning": "prerelease"` in `release-please-config.json`. With the [PrereleaseVersioningStrategy](https://github.com/googleapis/release-please/blob/main/src/versioning-strategies/prerelease.ts), a major bump on a version whose `minor` and `patch` are both `0` and which already carries a prerelease tag increments only the prerelease number:

`4.0.0-beta.0` + `feat!` → `4.0.0-beta.1`

Once this lands on `master`, the release workflow re-runs and rewrites #1405 to `4.0.0-beta.1` automatically.

Cutting the stable `4.0.0` later requires an explicit `Release-As: 4.0.0` commit footer (or flipping `prerelease` off in the config).

Also syncs the stale Release Process section in `.agents/conventions.md` (it still said `prerelease-type: alpha`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Process**
  * Updated prerelease versioning to use beta identifiers, such as `v4.0.0-beta.0`.
  * Additional prerelease changes now increment the beta number while preserving the target stable version.
  * Clarified how to publish the stable `4.0.0` release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->